### PR TITLE
revert back to GUID

### DIFF
--- a/src/Microsoft.Identity.Abstractions/TokenAcquisition/AcquireTokenOptions.cs
+++ b/src/Microsoft.Identity.Abstractions/TokenAcquisition/AcquireTokenOptions.cs
@@ -63,7 +63,7 @@ namespace Microsoft.Identity.Abstractions
         /// <summary>
         /// Sets the correlation id to be used in the request to the STS "/token" endpoint.
         /// </summary>
-        public string? CorrelationId { get; set; }
+        public Guid? CorrelationId { get; set; }
 
         /// <summary>
         /// Sets query parameters for the query string in the HTTP request to the 


### PR DESCRIPTION
Reverting back the change of the GUID to a string.
As this is would be a breaking change for IDownstreamWebApi options