### PR TITLE
Adding a new CredentialSource SignedAssertionFromVault.

### DIFF
--- a/src/Microsoft.Identity.Abstractions/ApplicationOptions/CredentialDescription.cs
+++ b/src/Microsoft.Identity.Abstractions/ApplicationOptions/CredentialDescription.cs
@@ -219,9 +219,18 @@ namespace Microsoft.Identity.Abstractions
             {
                 return SourceType switch
                 {
-                    CredentialSource.KeyVault or CredentialSource.Path or CredentialSource.StoreWithThumbprint or CredentialSource.StoreWithDistinguishedName or CredentialSource.Certificate or CredentialSource.Base64Encoded => CredentialType.Certificate,
+                    CredentialSource.KeyVault 
+                    or CredentialSource.Path 
+                    or CredentialSource.StoreWithThumbprint 
+                    or CredentialSource.StoreWithDistinguishedName 
+                    or CredentialSource.Certificate 
+                    or CredentialSource.Base64Encoded => CredentialType.Certificate,
+                    
                     CredentialSource.ClientSecret => CredentialType.Secret,
-                    CredentialSource.SignedAssertionFromManagedIdentity or CredentialSource.SignedAssertionFilePath => CredentialType.SignedAssertion,
+                    
+                    CredentialSource.SignedAssertionFromManagedIdentity 
+                    or CredentialSource.SignedAssertionFilePath 
+                    or CredentialSource.SignedAssertionFromVault => CredentialType.SignedAssertion,
                     _ => default,
                 };
             }

--- a/src/Microsoft.Identity.Abstractions/ApplicationOptions/CredentialSource.cs
+++ b/src/Microsoft.Identity.Abstractions/ApplicationOptions/CredentialSource.cs
@@ -52,5 +52,10 @@ namespace Microsoft.Identity.Abstractions
         /// Path to the file containing the signed assertion (for Kubernetes).
         /// </summary>
         SignedAssertionFilePath = 8,
+
+        /// <summary>
+        /// URI to the vault.
+        /// </summary>
+        SignedAssertionFromVault = 9,
     }
 }

--- a/src/Microsoft.Identity.Abstractions/ApplicationOptions/CredentialSourceLoaderParameters.cs
+++ b/src/Microsoft.Identity.Abstractions/ApplicationOptions/CredentialSourceLoaderParameters.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+namespace Microsoft.Identity.Abstractions
+{
+    /// <summary>
+    /// Parameters that credential loaders can use. This is for example the
+    /// case for signed assertion providers.
+    /// </summary>
+    public class CredentialSourceLoaderParameters
+    {
+        /// <summary>
+        /// Constructor
+        /// </summary>
+        /// <param name="clientId">Application ID of the confidential client application that
+        /// wants to use these credentials as client credentials</param>
+        /// <param name="authority">ID of the tenant in which the application is running.</param>
+        public CredentialSourceLoaderParameters(string clientId, string authority)
+        {
+            ClientId = clientId;
+            Authority = authority;
+        }
+
+        /// <summary>
+        /// Application ID of the confidential client application that
+        /// wants to use these credentials as client credentials.
+        /// </summary>
+        public string ClientId { get; set; }
+
+        /// <summary>
+        /// Authority (Cloud instance and tenant).
+        /// </summary>
+        public string Authority { get; set; }
+    }
+}

--- a/src/Microsoft.Identity.Abstractions/ApplicationOptions/ICredentialSourceLoader.cs
+++ b/src/Microsoft.Identity.Abstractions/ApplicationOptions/ICredentialSourceLoader.cs
@@ -14,7 +14,8 @@ namespace Microsoft.Identity.Abstractions
         /// Load the credential from the description, if needed.
         /// </summary>
         /// <param name="credentialDescription">Description of the credential.</param>
-        Task LoadIfNeededAsync(CredentialDescription credentialDescription);
+        /// <param name="parameters">Parameters, related to the host application, that the credential source loader can use.</param>
+        Task LoadIfNeededAsync(CredentialDescription credentialDescription, CredentialSourceLoaderParameters ?parameters = null);
 
         /// <summary>
         /// Loadable CredentialSource.

--- a/src/Microsoft.Identity.Abstractions/ApplicationOptions/ICredentialSourceLoader.cs
+++ b/src/Microsoft.Identity.Abstractions/ApplicationOptions/ICredentialSourceLoader.cs
@@ -15,7 +15,7 @@ namespace Microsoft.Identity.Abstractions
         /// </summary>
         /// <param name="credentialDescription">Description of the credential.</param>
         /// <param name="parameters">Parameters, related to the host application, that the credential source loader can use.</param>
-        Task LoadIfNeededAsync(CredentialDescription credentialDescription, CredentialSourceLoaderParameters ?parameters = null);
+        Task LoadIfNeededAsync(CredentialDescription credentialDescription, CredentialSourceLoaderParameters? parameters = null);
 
         /// <summary>
         /// Loadable CredentialSource.

--- a/src/Microsoft.Identity.Abstractions/ApplicationOptions/ICredentialsLoader.cs
+++ b/src/Microsoft.Identity.Abstractions/ApplicationOptions/ICredentialsLoader.cs
@@ -2,8 +2,6 @@
 // Licensed under the MIT License.
 
 using System.Collections.Generic;
-using System.Linq;
-using System.Security.Cryptography.X509Certificates;
 using System.Threading.Tasks;
 
 namespace Microsoft.Identity.Abstractions
@@ -23,15 +21,17 @@ namespace Microsoft.Identity.Abstractions
         /// Load a given credential description, if needed.
         /// </summary>
         /// <param name="credentialDescription">Description of the credentials to load.</param>
-        Task LoadCredentialsIfNeededAsync(CredentialDescription credentialDescription);
+        /// <param name="parameters">Parameters, related to the host application, that the credential source loader can use.</param>
+        Task LoadCredentialsIfNeededAsync(CredentialDescription credentialDescription, CredentialSourceLoaderParameters? parameters = null);
 
         /// <summary>
         /// Load the first valid credential from the credentials description list.
         /// </summary>
         /// <param name="credentialDescriptions">Description of the credentials.</param>
+        /// <param name="parameters">Parameters, related to the host application, that the credential source loader can use.</param>
         /// <returns>First valid credential description that could be loaded from the credential description list.
         /// <c>null</c> if none is valid.</returns>
-        Task<CredentialDescription?> LoadFirstValidCredentialsAsync(IEnumerable<CredentialDescription> credentialDescriptions);
+        Task<CredentialDescription?> LoadFirstValidCredentialsAsync(IEnumerable<CredentialDescription> credentialDescriptions, CredentialSourceLoaderParameters? parameters = null);
 
         /// <summary>
         /// Resets resettable credentials in the credential description list (for instance reset the 

--- a/src/Microsoft.Identity.Abstractions/DownstreamRestApi/IAuthorizationHeaderProvider.cs
+++ b/src/Microsoft.Identity.Abstractions/DownstreamRestApi/IAuthorizationHeaderProvider.cs
@@ -29,7 +29,7 @@ namespace Microsoft.Identity.Abstractions
             IEnumerable<string> scopes, 
             DownstreamRestApiOptions? downstreamApiOptions=null, 
             ClaimsPrincipal? claimsPrincipal=null,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Creates the authorization header used to call a protected web API on behalf
@@ -45,6 +45,6 @@ namespace Microsoft.Identity.Abstractions
         Task<string> CreateAuthorizationHeaderForAppAsync(
             string scopes,
             DownstreamRestApiOptions? downstreamApiOptions = null,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default);
     }
 }

--- a/src/Microsoft.Identity.Abstractions/TokenAcquisition/ITokenAcquirer.cs
+++ b/src/Microsoft.Identity.Abstractions/TokenAcquisition/ITokenAcquirer.cs
@@ -28,7 +28,7 @@ namespace Microsoft.Identity.Abstractions
             IEnumerable<string> scopes,
             AcquireTokenOptions? tokenAcquisitionOptions = null,
             ClaimsPrincipal? user = null,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Acquires an authentication result from the authority configured in the app, for the confidential client itself (not on behalf of a user)
@@ -45,6 +45,6 @@ namespace Microsoft.Identity.Abstractions
         Task<AcquireTokenResult> GetTokenForAppAsync(
             string scope,
             AcquireTokenOptions? tokenAcquisitionOptions = null,
-            CancellationToken cancellationToken = default(CancellationToken));
+            CancellationToken cancellationToken = default);
     }
 }


### PR DESCRIPTION
Adding a new CredentialSource SignedAssertionFromVault.
Computing the signed assertion for client credentials require
ClientId and authority, hence adding optional parameters
CredentialsSourceLoaderParameters, which are now passed to the
credential loader methods.

Clean-up