### PR TITLE
Add unreferenced code attributes 

### DIFF
--- a/src/Microsoft.Identity.Abstractions/DownstreamApi/IDownstreamApi.HttpMethods.cs
+++ b/src/Microsoft.Identity.Abstractions/DownstreamApi/IDownstreamApi.HttpMethods.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TInput and/or TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
+        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
 #endif
         public Task<TOutput?> GetForUserAsync<TOutput>(
             string? serviceName,
@@ -85,7 +85,7 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TInput and/or TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
+        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
 #endif
         public Task<TOutput?> GetForUserAsync<TInput, TOutput>(
             string? serviceName,
@@ -119,7 +119,7 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TInput and/or TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
+        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
 #endif
         public Task<TOutput?> GetForAppAsync<TOutput>(
             string? serviceName,
@@ -154,7 +154,7 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TInput and/or TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
+        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
 #endif
         public Task<TOutput?> GetForAppAsync<TInput, TOutput>(
             string? serviceName,
@@ -192,7 +192,7 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TInput and/or TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
+        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
 #endif
         public Task PostForUserAsync<TInput>(
             string? serviceName,
@@ -232,7 +232,7 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TInput and/or TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
+        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
 #endif
         public Task<TOutput?> PostForUserAsync<TInput, TOutput>(
             string? serviceName,
@@ -268,7 +268,7 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TInput and/or TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
+        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
 #endif
         public Task PostForAppAsync<TInput>(
             string? serviceName,
@@ -304,7 +304,7 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TInput and/or TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
+        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
 #endif
         public Task<TOutput?> PostForAppAsync<TInput, TOutput>(
             string? serviceName,
@@ -342,7 +342,7 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TInput and/or TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
+        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
 #endif
         public Task PutForUserAsync<TInput>(
             string? serviceName,
@@ -382,7 +382,7 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TInput and/or TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
+        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
 #endif
         public Task<TOutput?> PutForUserAsync<TInput, TOutput>(
             string? serviceName,
@@ -418,7 +418,7 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TInput and/or TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
+        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
 #endif
         public Task PutForAppAsync<TInput>(
             string? serviceName,
@@ -454,7 +454,7 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TInput and/or TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
+        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
 #endif
         public Task<TOutput?> PutForAppAsync<TInput, TOutput>(
             string? serviceName,
@@ -494,7 +494,7 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TInput and/or TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
+        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
 #endif
         public Task PatchForUserAsync<TInput>(
             string? serviceName,
@@ -534,7 +534,7 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TInput and/or TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
+        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
 #endif
         public Task<TOutput?> PatchForUserAsync<TInput, TOutput>(
             string? serviceName,
@@ -570,7 +570,7 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TInput and/or TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
+        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
 #endif
         public Task PatchForAppAsync<TInput>(
             string? serviceName,
@@ -606,7 +606,7 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TInput and/or TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
+        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
 #endif
         public Task<TOutput?> PatchForAppAsync<TInput, TOutput>(
             string? serviceName,
@@ -646,7 +646,7 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TInput and/or TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
+        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
 #endif
         public Task DeleteForUserAsync<TInput>(
             string? serviceName,
@@ -686,7 +686,7 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TInput and/or TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
+        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
 #endif
         public Task<TOutput?> DeleteForUserAsync<TInput, TOutput>(
             string? serviceName,
@@ -722,7 +722,7 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TInput and/or TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
+        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
 #endif
         public Task DeleteForAppAsync<TInput>(
             string? serviceName,
@@ -758,7 +758,7 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TInput and/or TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
+        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
 #endif
         public Task<TOutput?> DeleteForAppAsync<TInput, TOutput>(
             string? serviceName,

--- a/src/Microsoft.Identity.Abstractions/DownstreamApi/IDownstreamApi.HttpMethods.cs
+++ b/src/Microsoft.Identity.Abstractions/DownstreamApi/IDownstreamApi.HttpMethods.cs
@@ -46,7 +46,7 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TOutput")]
+        [RequiresUnreferencedCode("Provide source generation for TInput and/or TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
 #endif
         public Task<TOutput?> GetForUserAsync<TOutput>(
             string? serviceName,
@@ -85,7 +85,7 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TInput and TOutput")]
+        [RequiresUnreferencedCode("Provide source generation for TInput and/or TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
 #endif
         public Task<TOutput?> GetForUserAsync<TInput, TOutput>(
             string? serviceName,
@@ -119,7 +119,7 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TOutput")]
+        [RequiresUnreferencedCode("Provide source generation for TInput and/or TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
 #endif
         public Task<TOutput?> GetForAppAsync<TOutput>(
             string? serviceName,
@@ -154,7 +154,7 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TInput and TOutput")]
+        [RequiresUnreferencedCode("Provide source generation for TInput and/or TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
 #endif
         public Task<TOutput?> GetForAppAsync<TInput, TOutput>(
             string? serviceName,
@@ -192,7 +192,7 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TInput")]
+        [RequiresUnreferencedCode("Provide source generation for TInput and/or TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
 #endif
         public Task PostForUserAsync<TInput>(
             string? serviceName,
@@ -232,7 +232,7 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TInput and TOutput")]
+        [RequiresUnreferencedCode("Provide source generation for TInput and/or TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
 #endif
         public Task<TOutput?> PostForUserAsync<TInput, TOutput>(
             string? serviceName,
@@ -268,7 +268,7 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TInput")]
+        [RequiresUnreferencedCode("Provide source generation for TInput and/or TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
 #endif
         public Task PostForAppAsync<TInput>(
             string? serviceName,
@@ -304,7 +304,7 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TInput and TOutput")]
+        [RequiresUnreferencedCode("Provide source generation for TInput and/or TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
 #endif
         public Task<TOutput?> PostForAppAsync<TInput, TOutput>(
             string? serviceName,
@@ -342,7 +342,7 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TInput")]
+        [RequiresUnreferencedCode("Provide source generation for TInput and/or TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
 #endif
         public Task PutForUserAsync<TInput>(
             string? serviceName,
@@ -382,7 +382,7 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TInput and TOutput")]
+        [RequiresUnreferencedCode("Provide source generation for TInput and/or TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
 #endif
         public Task<TOutput?> PutForUserAsync<TInput, TOutput>(
             string? serviceName,
@@ -418,7 +418,7 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TInput")]
+        [RequiresUnreferencedCode("Provide source generation for TInput and/or TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
 #endif
         public Task PutForAppAsync<TInput>(
             string? serviceName,
@@ -454,7 +454,7 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TInput")]
+        [RequiresUnreferencedCode("Provide source generation for TInput and/or TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
 #endif
         public Task<TOutput?> PutForAppAsync<TInput, TOutput>(
             string? serviceName,
@@ -494,7 +494,7 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TInput")]
+        [RequiresUnreferencedCode("Provide source generation for TInput and/or TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
 #endif
         public Task PatchForUserAsync<TInput>(
             string? serviceName,
@@ -534,7 +534,7 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TInput and TOutput")]
+        [RequiresUnreferencedCode("Provide source generation for TInput and/or TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
 #endif
         public Task<TOutput?> PatchForUserAsync<TInput, TOutput>(
             string? serviceName,
@@ -570,7 +570,7 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Calls Microsoft.Identity.Web.DownstreamApi.SerializeOutput<TOutput>(HttpResponseMessage, DownstreamApiOptions)")]
+        [RequiresUnreferencedCode("Provide source generation for TInput and/or TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
 #endif
         public Task PatchForAppAsync<TInput>(
             string? serviceName,
@@ -606,7 +606,7 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TInput and TOutput")]
+        [RequiresUnreferencedCode("Provide source generation for TInput and/or TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
 #endif
         public Task<TOutput?> PatchForAppAsync<TInput, TOutput>(
             string? serviceName,
@@ -646,7 +646,7 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TInput")]
+        [RequiresUnreferencedCode("Provide source generation for TInput and/or TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
 #endif
         public Task DeleteForUserAsync<TInput>(
             string? serviceName,
@@ -686,7 +686,7 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TInput and TOutput")]
+        [RequiresUnreferencedCode("Provide source generation for TInput and/or TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
 #endif
         public Task<TOutput?> DeleteForUserAsync<TInput, TOutput>(
             string? serviceName,
@@ -722,7 +722,7 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TInput")]
+        [RequiresUnreferencedCode("Provide source generation for TInput and/or TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
 #endif
         public Task DeleteForAppAsync<TInput>(
             string? serviceName,
@@ -758,7 +758,7 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TInput and TOutput")]
+        [RequiresUnreferencedCode("Provide source generation for TInput and/or TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
 #endif
         public Task<TOutput?> DeleteForAppAsync<TInput, TOutput>(
             string? serviceName,

--- a/src/Microsoft.Identity.Abstractions/DownstreamApi/IDownstreamApi.HttpMethods.cs
+++ b/src/Microsoft.Identity.Abstractions/DownstreamApi/IDownstreamApi.HttpMethods.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using System.Security.Claims;
 using System.Threading;
@@ -44,6 +45,9 @@ namespace Microsoft.Identity.Abstractions
         ///         });
         /// </code>
         /// </example>
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("Provide source generation for TOutput")]
+#endif
         public Task<TOutput?> GetForUserAsync<TOutput>(
             string? serviceName,
             Action<DownstreamApiOptionsReadOnlyHttpMethod>? downstreamApiOptionsOverride = null,
@@ -80,6 +84,9 @@ namespace Microsoft.Identity.Abstractions
         ///         });
         /// </code>
         /// </example>
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("Provide source generation for TInput and TOutput")]
+#endif
         public Task<TOutput?> GetForUserAsync<TInput, TOutput>(
             string? serviceName,
             TInput input,
@@ -111,6 +118,9 @@ namespace Microsoft.Identity.Abstractions
         ///         });
         /// </code>
         /// </example>
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("Provide source generation for TOutput")]
+#endif
         public Task<TOutput?> GetForAppAsync<TOutput>(
             string? serviceName,
             Action<DownstreamApiOptionsReadOnlyHttpMethod>? downstreamApiOptionsOverride = null,
@@ -143,6 +153,9 @@ namespace Microsoft.Identity.Abstractions
         ///         });
         /// </code>
         /// </example>
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("Provide source generation for TInput and TOutput")]
+#endif
         public Task<TOutput?> GetForAppAsync<TInput, TOutput>(
             string? serviceName,
             TInput input,
@@ -178,6 +191,9 @@ namespace Microsoft.Identity.Abstractions
         ///         });
         /// </code>
         /// </example>
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("Provide source generation for TInput")]
+#endif
         public Task PostForUserAsync<TInput>(
             string? serviceName,
             TInput input,
@@ -215,6 +231,9 @@ namespace Microsoft.Identity.Abstractions
         ///         });
         /// </code>
         /// </example>
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("Provide source generation for TInput and TOutput")]
+#endif
         public Task<TOutput?> PostForUserAsync<TInput, TOutput>(
             string? serviceName,
             TInput input,
@@ -248,6 +267,9 @@ namespace Microsoft.Identity.Abstractions
         ///         });
         /// </code>
         /// </example>
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("Provide source generation for TInput")]
+#endif
         public Task PostForAppAsync<TInput>(
             string? serviceName,
             TInput input,
@@ -281,6 +303,9 @@ namespace Microsoft.Identity.Abstractions
         ///         });
         /// </code>
         /// </example>
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("Provide source generation for TInput and TOutput")]
+#endif
         public Task<TOutput?> PostForAppAsync<TInput, TOutput>(
             string? serviceName,
             TInput input,
@@ -316,6 +341,9 @@ namespace Microsoft.Identity.Abstractions
         ///         });
         /// </code>
         /// </example>
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("Provide source generation for TInput")]
+#endif
         public Task PutForUserAsync<TInput>(
             string? serviceName,
             TInput input,
@@ -353,6 +381,9 @@ namespace Microsoft.Identity.Abstractions
         ///         });
         /// </code>
         /// </example>
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("Provide source generation for TInput and TOutput")]
+#endif
         public Task<TOutput?> PutForUserAsync<TInput, TOutput>(
             string? serviceName,
             TInput input,
@@ -386,6 +417,9 @@ namespace Microsoft.Identity.Abstractions
         ///         });
         /// </code>
         /// </example>
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("Provide source generation for TInput")]
+#endif
         public Task PutForAppAsync<TInput>(
             string? serviceName,
             TInput input,
@@ -419,6 +453,9 @@ namespace Microsoft.Identity.Abstractions
         ///         });
         /// </code>
         /// </example>
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("Provide source generation for TInput")]
+#endif
         public Task<TOutput?> PutForAppAsync<TInput, TOutput>(
             string? serviceName,
             TInput input,
@@ -456,6 +493,9 @@ namespace Microsoft.Identity.Abstractions
         ///         });
         /// </code>
         /// </example>
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("Provide source generation for TInput")]
+#endif
         public Task PatchForUserAsync<TInput>(
             string? serviceName,
             TInput input,
@@ -493,6 +533,9 @@ namespace Microsoft.Identity.Abstractions
         ///         });
         /// </code>
         /// </example>
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("Provide source generation for TInput and TOutput")]
+#endif
         public Task<TOutput?> PatchForUserAsync<TInput, TOutput>(
             string? serviceName,
             TInput input,
@@ -526,6 +569,9 @@ namespace Microsoft.Identity.Abstractions
         ///         });
         /// </code>
         /// </example>
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("Calls Microsoft.Identity.Web.DownstreamApi.SerializeOutput<TOutput>(HttpResponseMessage, DownstreamApiOptions)")]
+#endif
         public Task PatchForAppAsync<TInput>(
             string? serviceName,
             TInput input,
@@ -559,6 +605,9 @@ namespace Microsoft.Identity.Abstractions
         ///         });
         /// </code>
         /// </example>
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("Provide source generation for TInput and TOutput")]
+#endif
         public Task<TOutput?> PatchForAppAsync<TInput, TOutput>(
             string? serviceName,
             TInput input,
@@ -596,6 +645,9 @@ namespace Microsoft.Identity.Abstractions
         ///         });
         /// </code>
         /// </example>
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("Provide source generation for TInput")]
+#endif
         public Task DeleteForUserAsync<TInput>(
             string? serviceName,
             TInput input,
@@ -633,6 +685,9 @@ namespace Microsoft.Identity.Abstractions
         ///         });
         /// </code>
         /// </example>
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("Provide source generation for TInput and TOutput")]
+#endif
         public Task<TOutput?> DeleteForUserAsync<TInput, TOutput>(
             string? serviceName,
             TInput input,
@@ -666,6 +721,9 @@ namespace Microsoft.Identity.Abstractions
         ///         });
         /// </code>
         /// </example>
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("Provide source generation for TInput")]
+#endif
         public Task DeleteForAppAsync<TInput>(
             string? serviceName,
             TInput input,
@@ -699,6 +757,9 @@ namespace Microsoft.Identity.Abstractions
         ///         });
         /// </code>
         /// </example>
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("Provide source generation for TInput and TOutput")]
+#endif
         public Task<TOutput?> DeleteForAppAsync<TInput, TOutput>(
             string? serviceName,
             TInput input,

--- a/src/Microsoft.Identity.Abstractions/DownstreamApi/IDownstreamApi.HttpMethods.tt
+++ b/src/Microsoft.Identity.Abstractions/DownstreamApi/IDownstreamApi.HttpMethods.tt
@@ -8,6 +8,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using System.Security.Claims;
 using System.Threading;
@@ -92,6 +93,9 @@ namespace Microsoft.Identity.Abstractions
         ///         });
         /// </code>
         /// </example>
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("Provide source generation for TInput and/or TOutput")]
+#endif
         public <#= returnType #> <#= httpMethod #>For<#= token #>Async<#= template #>(
             string? serviceName,
 <# if (hasInput){ #>

--- a/src/Microsoft.Identity.Abstractions/DownstreamApi/IDownstreamApi.HttpMethods.tt
+++ b/src/Microsoft.Identity.Abstractions/DownstreamApi/IDownstreamApi.HttpMethods.tt
@@ -94,7 +94,7 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TInput and/or TOutput")]
+        [RequiresUnreferencedCode("Provide source generation for TInput and/or TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
 #endif
         public <#= returnType #> <#= httpMethod #>For<#= token #>Async<#= template #>(
             string? serviceName,

--- a/src/Microsoft.Identity.Abstractions/DownstreamApi/IDownstreamApi.HttpMethods.tt
+++ b/src/Microsoft.Identity.Abstractions/DownstreamApi/IDownstreamApi.HttpMethods.tt
@@ -94,7 +94,7 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TInput and/or TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
+        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
 #endif
         public <#= returnType #> <#= httpMethod #>For<#= token #>Async<#= template #>(
             string? serviceName,

--- a/src/Microsoft.Identity.Abstractions/DownstreamApi/IDownstreamApi.cs
+++ b/src/Microsoft.Identity.Abstractions/DownstreamApi/IDownstreamApi.cs
@@ -157,7 +157,7 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TInput and TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
+        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
 #endif
         Task<TOutput?> CallApiForUserAsync<TInput, TOutput>(
             string? serviceName,
@@ -183,7 +183,7 @@ namespace Microsoft.Identity.Abstractions
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The value returned by the downstream web API.</returns>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TInput and TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
+        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
 #endif
         Task<TOutput?> CallApiForUserAsync<TOutput>(
             string serviceName,
@@ -207,7 +207,7 @@ namespace Microsoft.Identity.Abstractions
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The value returned by the downstream web API.</returns>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TInput and TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
+        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
 #endif
         Task<TOutput?> CallApiForAppAsync<TInput, TOutput>(
             string? serviceName,
@@ -229,7 +229,7 @@ namespace Microsoft.Identity.Abstractions
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The value returned by the downstream web API.</returns>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TInput and TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
+        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
 #endif
         Task<TOutput?> CallApiForAppAsync<TOutput>(
             string serviceName,

--- a/src/Microsoft.Identity.Abstractions/DownstreamApi/IDownstreamApi.cs
+++ b/src/Microsoft.Identity.Abstractions/DownstreamApi/IDownstreamApi.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Diagnostics.CodeAnalysis;
 using System.Net.Http;
 using System.Security.Claims;
 using System.Threading;
@@ -155,6 +156,9 @@ namespace Microsoft.Identity.Abstractions
         /// }
         /// </code>
         /// </example>
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("Provide source generation for TInput and TOutput")]
+#endif
         Task<TOutput?> CallApiForUserAsync<TInput, TOutput>(
             string? serviceName,
             TInput input,
@@ -178,6 +182,9 @@ namespace Microsoft.Identity.Abstractions
         /// will find the user from the HttpContext.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The value returned by the downstream web API.</returns>
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("Provide source generation for TInput and TOutput")]
+#endif
         Task<TOutput?> CallApiForUserAsync<TOutput>(
             string serviceName,
             Action<DownstreamApiOptions>? downstreamApiOptionsOverride = null,
@@ -199,6 +206,9 @@ namespace Microsoft.Identity.Abstractions
         /// by <paramref name="serviceName"/>.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The value returned by the downstream web API.</returns>
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("Provide source generation for TInput and TOutput")]
+#endif
         Task<TOutput?> CallApiForAppAsync<TInput, TOutput>(
             string? serviceName,
             TInput input,
@@ -218,6 +228,9 @@ namespace Microsoft.Identity.Abstractions
         /// by <paramref name="serviceName"/>.</param>
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The value returned by the downstream web API.</returns>
+#if NET6_0_OR_GREATER
+        [RequiresUnreferencedCode("Provide source generation for TInput and TOutput")]
+#endif
         Task<TOutput?> CallApiForAppAsync<TOutput>(
             string serviceName,
             Action<DownstreamApiOptions>? downstreamApiOptionsOverride = null,

--- a/src/Microsoft.Identity.Abstractions/DownstreamApi/IDownstreamApi.cs
+++ b/src/Microsoft.Identity.Abstractions/DownstreamApi/IDownstreamApi.cs
@@ -157,7 +157,7 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TInput and TOutput")]
+        [RequiresUnreferencedCode("Provide source generation for TInput and TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
 #endif
         Task<TOutput?> CallApiForUserAsync<TInput, TOutput>(
             string? serviceName,
@@ -183,7 +183,7 @@ namespace Microsoft.Identity.Abstractions
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The value returned by the downstream web API.</returns>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TInput and TOutput")]
+        [RequiresUnreferencedCode("Provide source generation for TInput and TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
 #endif
         Task<TOutput?> CallApiForUserAsync<TOutput>(
             string serviceName,
@@ -207,7 +207,7 @@ namespace Microsoft.Identity.Abstractions
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The value returned by the downstream web API.</returns>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TInput and TOutput")]
+        [RequiresUnreferencedCode("Provide source generation for TInput and TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
 #endif
         Task<TOutput?> CallApiForAppAsync<TInput, TOutput>(
             string? serviceName,
@@ -229,7 +229,7 @@ namespace Microsoft.Identity.Abstractions
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The value returned by the downstream web API.</returns>
 #if NET6_0_OR_GREATER
-        [RequiresUnreferencedCode("Provide source generation for TInput and TOutput")]
+        [RequiresUnreferencedCode("Provide source generation for TInput and TOutput. See https://aka.ms/ms-id-web/il-trimming/generator")]
 #endif
         Task<TOutput?> CallApiForAppAsync<TOutput>(
             string serviceName,


### PR DESCRIPTION
The implementations of the methods receiving these attributes are not trim-friendly, so the warning is being bubbled up to these base members.