### PR TITLE
update langVersion

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -10,13 +10,13 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2.3.4     
-    - name: Setup .NET 7.0.x
+    - name: Setup .NET 8.0.x
       uses: actions/setup-dotnet@v1.7.2
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 8.0.x
   
     # Run the tests  
-    - name: Build with .NET 7.0.x
+    - name: Build with .NET 8.0.x
       run: dotnet test --configuration Release Microsoft.Identity.Abstractions.sln
       
     # Run the tests  

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,7 +25,7 @@
 		<AssemblyOriginatorKeyFile>../../build/MSAL.snk</AssemblyOriginatorKeyFile>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<Nullable>enable</Nullable>
-		<LangVersion>8</LangVersion>
+		<LangVersion>9.0</LangVersion>
 		<PackageVersion>5.1.0</PackageVersion>
 		<EnablePackageValidation>true</EnablePackageValidation>
 		<PackageValidationBaselineVersion>5.0.0</PackageValidationBaselineVersion>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,7 +25,7 @@
 		<AssemblyOriginatorKeyFile>../../build/MSAL.snk</AssemblyOriginatorKeyFile>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<Nullable>enable</Nullable>
-		<LangVersion>9.0</LangVersion>
+		<LangVersion>12</LangVersion>
 		<PackageVersion>5.1.0</PackageVersion>
 		<EnablePackageValidation>true</EnablePackageValidation>
 		<PackageValidationBaselineVersion>5.0.0</PackageValidationBaselineVersion>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -25,7 +25,7 @@
 		<AssemblyOriginatorKeyFile>../../build/MSAL.snk</AssemblyOriginatorKeyFile>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<Nullable>enable</Nullable>
-		<LangVersion>12</LangVersion>
+		<LangVersion>8</LangVersion>
 		<PackageVersion>5.1.0</PackageVersion>
 		<EnablePackageValidation>true</EnablePackageValidation>
 		<PackageValidationBaselineVersion>5.0.0</PackageValidationBaselineVersion>

--- a/build/template-install-dotnet-core.yaml
+++ b/build/template-install-dotnet-core.yaml
@@ -4,6 +4,6 @@
 steps:
 
 - task: UseDotNet@2
-  displayName: 'Use .Net Core SDK 7'
+  displayName: 'Use .Net Core SDK 8'
   inputs:
-    version: 7.0.x 
+    version: 8.0.x 

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -5,7 +5,6 @@
   </PropertyGroup>
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0</TargetFrameworks>
 		<MicrosoftNetTestSdkVersion>17.3.2</MicrosoftNetTestSdkVersion>
 		<!-- GHSA-5crp-9r3c-p9vr -->
 		<NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -5,6 +5,7 @@
   </PropertyGroup>
 
 	<PropertyGroup>
+		<TargetFrameworks>net8.0</TargetFrameworks>
 		<MicrosoftNetTestSdkVersion>17.3.2</MicrosoftNetTestSdkVersion>
 		<!-- GHSA-5crp-9r3c-p9vr -->
 		<NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>

--- a/test/Microsoft.Identity.Abstractions.Tests/Microsoft.Identity.Abstractions.Tests.csproj
+++ b/test/Microsoft.Identity.Abstractions.Tests/Microsoft.Identity.Abstractions.Tests.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net462</TargetFrameworks>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-	<LangVersion>11</LangVersion>
+	<LangVersion>12</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Identity.Abstractions.Tests/Microsoft.Identity.Abstractions.Tests.csproj
+++ b/test/Microsoft.Identity.Abstractions.Tests/Microsoft.Identity.Abstractions.Tests.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net7.0;net462</TargetFrameworks>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-	<LangVersion>9.0</LangVersion>
+	<LangVersion>12</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Microsoft.Identity.Abstractions.Tests/Microsoft.Identity.Abstractions.Tests.csproj
+++ b/test/Microsoft.Identity.Abstractions.Tests/Microsoft.Identity.Abstractions.Tests.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>net7.0;net462</TargetFrameworks>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
-	<LangVersion>12</LangVersion>
+	<LangVersion>11</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Edit: discussion below yielded that we could in fact update to 12.

Could only update to 11 (not 12) since this is targeting .NET 7

![image](https://github.com/AzureAD/microsoft-identity-abstractions-for-dotnet/assets/69649063/c5c241ee-3562-41f8-8d83-2c61dbd8f0be)
https://learn.microsoft.com/en-us/dotnet/csharp/language-reference/configure-language-version#defaults