### PR TITLE
Fixed invalid JSON example

### DIFF
--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -21,4 +21,4 @@ jobs:
       
     # Run the tests  
     - name: Pack
-      run: dotnet pack --configuration Release Microsoft.Identity.Abstractions.sln 
+      run: dotnet pack --configuration --no-restore --no-build Release Microsoft.Identity.Abstractions.sln 

--- a/.github/workflows/dotnetcore.yml
+++ b/.github/workflows/dotnetcore.yml
@@ -17,8 +17,8 @@ jobs:
   
     # Run the tests  
     - name: Build with .NET 8.0.x
-      run: dotnet test --configuration Release Microsoft.Identity.Abstractions.sln
+      run: dotnet test -v m --configuration Release Microsoft.Identity.Abstractions.sln
       
     # Run the tests  
     - name: Pack
-      run: dotnet pack --configuration --no-restore --no-build Release Microsoft.Identity.Abstractions.sln 
+      run: dotnet pack --configuration Release --no-restore --no-build -v m Microsoft.Identity.Abstractions.sln 

--- a/test/Microsoft.Identity.Abstractions.Tests/AquireTokenOptionsTests.cs
+++ b/test/Microsoft.Identity.Abstractions.Tests/AquireTokenOptionsTests.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Identity.Abstractions.Tests
             // <managedidentity_json>
             {
                 "AquireTokenOptions": {
-                    "ManagedIdentity"
+                    "ManagedIdentity": {}
                 }
             }
             // </managedidentitysystem_json>


### PR DESCRIPTION
Added an empty value to JSON object in config example to fix what was otherwise a malformed JSON example.
