### PR TITLE
add tokenExchangeUrl to CredentialDescription

### DIFF
--- a/src/Microsoft.Identity.Abstractions/ApplicationOptions/CredentialDescription.cs
+++ b/src/Microsoft.Identity.Abstractions/ApplicationOptions/CredentialDescription.cs
@@ -460,5 +460,22 @@ namespace Microsoft.Identity.Abstractions
                 };
             }
         }
+
+        /// <summary>
+        /// (Microsoft identity specific)
+        /// Value that can be used to configure the token exchange resource url.
+        /// </summary>
+        /// /// <example>
+        /// <format type="text/markdown">
+        /// <![CDATA[
+        /// The JSON fragment below describes a workload identity federation with a user assigned managed identity:
+        /// :::code language="json" source="~/../abstractions-samples/test/Microsoft.Identity.Abstractions.Tests/CredentialDescriptionTest.cs" id="tokenExchangeUrl_json":::
+        /// 
+        /// The code below describes programmatically in C#, the same workload identity federation with a user assigned managed identity.
+        /// :::code language="csharp" source="~/../abstractions-samples/test/Microsoft.Identity.Abstractions.Tests/CredentialDescriptionTest.cs" id="tokenExchangeUrl_csharp":::
+        /// ]]></format>
+        /// </example> 
+        /// <remarks>If you want to use the default token exchange resource "api://AzureADTokenExchange", don't provide a token exchange url.</remarks>
+        public string? TokenExchangeUrl { get; set; }
     }
 }

--- a/src/Microsoft.Identity.Abstractions/ApplicationOptions/CredentialDescription.cs
+++ b/src/Microsoft.Identity.Abstractions/ApplicationOptions/CredentialDescription.cs
@@ -462,7 +462,7 @@ namespace Microsoft.Identity.Abstractions
         }
 
         /// <summary>
-        /// (Microsoft identity specific)
+        /// (Microsoft Entra specific)
         /// Value that can be used to configure the token exchange resource url.
         /// </summary>
         /// /// <example>

--- a/src/Microsoft.Identity.Abstractions/ApplicationOptions/CredentialDescription.cs
+++ b/src/Microsoft.Identity.Abstractions/ApplicationOptions/CredentialDescription.cs
@@ -463,7 +463,8 @@ namespace Microsoft.Identity.Abstractions
 
         /// <summary>
         /// (Microsoft Entra specific)
-        /// Value that can be used to configure the token exchange resource url.
+        /// Value that can be used to configure the token exchange resource url in the case
+        /// of federation identity credentials with Managed identity.
         /// </summary>
         /// /// <example>
         /// <format type="text/markdown">

--- a/test/Microsoft.Identity.Abstractions.Tests/CredentialDescriptionTest.cs
+++ b/test/Microsoft.Identity.Abstractions.Tests/CredentialDescriptionTest.cs
@@ -343,6 +343,32 @@ namespace Microsoft.Identity.Abstractions.ApplicationOptions.Tests
         }
 
         [Fact]
+        public void TokenExchangeUrl()
+        {
+            /*
+            // <tokenExchangeUrl_json>
+            {
+                "ClientCredentials": [
+                {
+                    "SourceType": "SignedAssertionFromManagedIdentity",
+                    "TokenExchangeUrl": "api://AzureADTokenExchangeChina"
+                }]
+            }
+            // </tokenExchangeUrl_json>
+            */
+
+            // <tokenExchangeUrl_csharp>
+            CredentialDescription credentialDescription = new CredentialDescription
+            {
+                SourceType = CredentialSource.SignedAssertionFromManagedIdentity,
+                TokenExchangeUrl = "api://AzureADTokenExchangeChina"
+            };
+            // </tokenExchangeUrl_csharp>
+
+            Assert.Equal("api://AzureADTokenExchangeChina", credentialDescription.TokenExchangeUrl);
+        }
+
+        [Fact]
         public void UnknownCredentialSource()
         {
             CredentialDescription credentialDescription = new CredentialDescription
@@ -361,8 +387,8 @@ namespace Microsoft.Identity.Abstractions.ApplicationOptions.Tests
             Assert.Null(credentialDescription.Container);
         }
 
-            // Both container and reference or value.
-            [Theory]
+        // Both container and reference or value.
+        [Theory]
         [InlineData(CredentialSource.Base64Encoded)]
         [InlineData(CredentialSource.StoreWithThumbprint)]
         [InlineData(CredentialSource.StoreWithDistinguishedName)]


### PR DESCRIPTION
In order to support configuring a tokenExchangeUrl in [IdWeb](https://github.com/AzureAD/microsoft-identity-web/issues/2749), added a tokenExchangeUrl property to Credential Description.

