### PR TITLE
Fixes a typo in the AuthenticationOptionsName documentation comment

### DIFF
--- a/src/Microsoft.Identity.Abstractions/TokenAcquisition/AcquireTokenOptions.cs
+++ b/src/Microsoft.Identity.Abstractions/TokenAcquisition/AcquireTokenOptions.cs
@@ -42,7 +42,7 @@ namespace Microsoft.Identity.Abstractions
 
         /// <summary>
         /// Gets the name of the options describing the confidential client application (ClientID,
-        /// Region, Authority, client credentials). In ASP.NET Core, the authenticatiopn options name 
+        /// Region, Authority, client credentials). In ASP.NET Core, the authentication options name
         /// is the same as the authentication scheme.
         /// </summary>
         public string? AuthenticationOptionsName { get; set; }


### PR DESCRIPTION
# Typo Fix
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the Microsoft.Identity.Abstractions repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/AzureAD/microsoft-identity-web/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/AzureAD/microsoft-identity-web/blob/master/CODE_OF_CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

Fixes a typo in the AcquireTokenOptions.AuthenticationOptionsName documentation comment.
