### PR TITLE
Enable source generator analyzers in pipeline

### DIFF
--- a/build/template-postbuild-code-analysis.yaml
+++ b/build/template-postbuild-code-analysis.yaml
@@ -6,6 +6,7 @@ steps:
   displayName: 'Run Roslyn Analyzers'
   inputs:
     userProvideBuildInfo: auto
+    loadRoslynConfiguredAnalyzersOption: Enable
   env:
     system_accesstoken: $(System.AccessToken)
   continueOnError: true


### PR DESCRIPTION
Enabling source generator analyzers in release pipeline to fix errors after merging https://github.com/AzureAD/microsoft-identity-abstractions-for-dotnet/pull/131 