### PR TITLE
Post release 7.1.0 - Update version to next and move unshipped public API to shipped

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
         <!-- This should be passed from the VSTS build -->
-        <MicrosoftIdentityAbstractionsVersion Condition="'$(MicrosoftIdentityAbstractionsVersion)' == ''">7.1.0</MicrosoftIdentityAbstractionsVersion>
+        <MicrosoftIdentityAbstractionsVersion Condition="'$(MicrosoftIdentityAbstractionsVersion)' == ''">7.1.1</MicrosoftIdentityAbstractionsVersion>
         <!-- This will generate AssemblyVersion, AssemblyFileVersion and AssemblyInformationVersion -->
         <Version>$(MicrosoftIdentityAbstractionsVersion)</Version>
         <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)\build\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/net462/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/net462/PublicAPI.Shipped.txt
@@ -246,3 +246,5 @@ virtual Microsoft.Identity.Abstractions.CredentialDescription.CachedValue.get ->
 virtual Microsoft.Identity.Abstractions.CredentialDescription.CachedValue.set -> void
 virtual Microsoft.Identity.Abstractions.IdentityApplicationOptions.Authority.get -> string?
 virtual Microsoft.Identity.Abstractions.IdentityApplicationOptions.Authority.set -> void
+Microsoft.Identity.Abstractions.AcquireTokenOptions.ExtraParameters.get -> System.Collections.Generic.IDictionary<string!, object!>?
+Microsoft.Identity.Abstractions.AcquireTokenOptions.ExtraParameters.set -> void

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/net462/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/net462/PublicAPI.Unshipped.txt
@@ -1,3 +1,1 @@
 #nullable enable
-Microsoft.Identity.Abstractions.AcquireTokenOptions.ExtraParameters.get -> System.Collections.Generic.IDictionary<string!, object!>?
-Microsoft.Identity.Abstractions.AcquireTokenOptions.ExtraParameters.set -> void

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -274,4 +274,6 @@ virtual Microsoft.Identity.Abstractions.CredentialDescription.CachedValue.get ->
 virtual Microsoft.Identity.Abstractions.CredentialDescription.CachedValue.set -> void
 virtual Microsoft.Identity.Abstractions.IdentityApplicationOptions.Authority.get -> string?
 virtual Microsoft.Identity.Abstractions.IdentityApplicationOptions.Authority.set -> void
+Microsoft.Identity.Abstractions.AcquireTokenOptions.ExtraParameters.get -> System.Collections.Generic.IDictionary<string!, object!>?
+Microsoft.Identity.Abstractions.AcquireTokenOptions.ExtraParameters.set -> void
 

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,1 @@
 #nullable enable
-Microsoft.Identity.Abstractions.AcquireTokenOptions.ExtraParameters.get -> System.Collections.Generic.IDictionary<string!, object!>?
-Microsoft.Identity.Abstractions.AcquireTokenOptions.ExtraParameters.set -> void

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -246,3 +246,5 @@ virtual Microsoft.Identity.Abstractions.CredentialDescription.CachedValue.get ->
 virtual Microsoft.Identity.Abstractions.CredentialDescription.CachedValue.set -> void
 virtual Microsoft.Identity.Abstractions.IdentityApplicationOptions.Authority.get -> string?
 virtual Microsoft.Identity.Abstractions.IdentityApplicationOptions.Authority.set -> void
+Microsoft.Identity.Abstractions.AcquireTokenOptions.ExtraParameters.get -> System.Collections.Generic.IDictionary<string!, object!>?
+Microsoft.Identity.Abstractions.AcquireTokenOptions.ExtraParameters.set -> void

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,1 @@
 #nullable enable
-Microsoft.Identity.Abstractions.AcquireTokenOptions.ExtraParameters.get -> System.Collections.Generic.IDictionary<string!, object!>?
-Microsoft.Identity.Abstractions.AcquireTokenOptions.ExtraParameters.set -> void

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.1/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.1/PublicAPI.Shipped.txt
@@ -250,3 +250,5 @@ virtual Microsoft.Identity.Abstractions.CredentialDescription.CachedValue.get ->
 virtual Microsoft.Identity.Abstractions.CredentialDescription.CachedValue.set -> void
 virtual Microsoft.Identity.Abstractions.IdentityApplicationOptions.Authority.get -> string?
 virtual Microsoft.Identity.Abstractions.IdentityApplicationOptions.Authority.set -> void
+Microsoft.Identity.Abstractions.AcquireTokenOptions.ExtraParameters.get -> System.Collections.Generic.IDictionary<string!, object!>?
+Microsoft.Identity.Abstractions.AcquireTokenOptions.ExtraParameters.set -> void

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
@@ -1,3 +1,1 @@
 #nullable enable
-Microsoft.Identity.Abstractions.AcquireTokenOptions.ExtraParameters.get -> System.Collections.Generic.IDictionary<string!, object!>?
-Microsoft.Identity.Abstractions.AcquireTokenOptions.ExtraParameters.set -> void


### PR DESCRIPTION
# Update MicrosoftIdentityAbstractionVersion to next (7.1.1) and move unshipped public API to shipped
