### PR TITLE
Add AppHomeTenantId to MicrosoftIdentityApplicationOptions

### DIFF
--- a/src/Microsoft.Identity.Abstractions/ApplicationOptions/MicrosoftIdentityApplicationOptions.cs
+++ b/src/Microsoft.Identity.Abstractions/ApplicationOptions/MicrosoftIdentityApplicationOptions.cs
@@ -39,6 +39,11 @@ namespace Microsoft.Identity.Abstractions
 
         #region Token acquisition
         /// <summary>
+        /// Home tenant of the app in which the app can acquire a token to call a downstream API on behalf of itself.
+        /// </summary>
+        public string? AppHomeTenantId { get; set; }
+
+        /// <summary>
         /// Specifies the Azure region. See https://aka.ms/azure-region. To have
         /// the app attempt to detect the Azure region automatically,
         /// use "TryAutoDetect".

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/net462/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/net462/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions.AppHomeTenantId.get -> string?
+Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions.AppHomeTenantId.set -> void

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions.AppHomeTenantId.get -> string?
+Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions.AppHomeTenantId.set -> void

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions.AppHomeTenantId.get -> string?
+Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions.AppHomeTenantId.set -> void

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions.AppHomeTenantId.get -> string?
+Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions.AppHomeTenantId.set -> void

--- a/test/Microsoft.Identity.Abstractions.Tests/MicrosoftIdentityApplicationOptionsTests.cs
+++ b/test/Microsoft.Identity.Abstractions.Tests/MicrosoftIdentityApplicationOptionsTests.cs
@@ -19,6 +19,7 @@ namespace Microsoft.Identity.Abstractions.ApplicationOptions.Tests
         private CredentialDescription secret = new() { SourceType = CredentialSource.ClientSecret, ClientSecret = "blah" };
         private CredentialDescription decryptCert = new CredentialDescription { SourceType = CredentialSource.Base64Encoded, Base64EncodedValue = "0123" };
         private string[] audiences = new[] { "https://myapi", clientId };
+        private const string appHomeTenantId = "this-is-a-tenant-guid";
 
         [Fact]
         public void MicrosoftIdentityApplicationOptionsProperties()
@@ -27,6 +28,7 @@ namespace Microsoft.Identity.Abstractions.ApplicationOptions.Tests
             {
                 Instance = instance,
                 TenantId = tenant,
+                AppHomeTenantId = appHomeTenantId,
                 ClientId = clientId,
                 Audience = audience,
                 AzureRegion = azureRegion,
@@ -59,6 +61,7 @@ namespace Microsoft.Identity.Abstractions.ApplicationOptions.Tests
             Assert.Equal("https://login.microsoftonline.com/common", microsoftIdentityApplicationOptions.Authority);
             Assert.Equal(clientId, microsoftIdentityApplicationOptions.ClientId);
             Assert.Equal(tenant, microsoftIdentityApplicationOptions.TenantId);
+            Assert.Equal(appHomeTenantId, microsoftIdentityApplicationOptions.AppHomeTenantId);
             Assert.Equal(clientId, microsoftIdentityApplicationOptions.Audience);
             Assert.Equal(clientCapabilities, microsoftIdentityApplicationOptions.ClientCapabilities);
             Assert.Equal(azureRegion, microsoftIdentityApplicationOptions.AzureRegion);


### PR DESCRIPTION
Add `AppHomeTenantId` to `MicrosoftIdentityApplicationOptions`. https://github.com/AzureAD/microsoft-identity-web/issues/3121