### PR TITLE
Fix #147

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
         <!-- This should be passed from the VSTS build -->
-        <MicrosoftIdentityAbstractionsVersion Condition="'$(MicrosoftIdentityAbstractionsVersion)' == ''">7.1.1</MicrosoftIdentityAbstractionsVersion>
+        <MicrosoftIdentityAbstractionsVersion Condition="'$(MicrosoftIdentityAbstractionsVersion)' == ''">7.2.1</MicrosoftIdentityAbstractionsVersion>
         <!-- This will generate AssemblyVersion, AssemblyFileVersion and AssemblyInformationVersion -->
         <Version>$(MicrosoftIdentityAbstractionsVersion)</Version>
         <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)\build\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>

--- a/src/Microsoft.Identity.Abstractions/ApplicationOptions/CredentialDescription.cs
+++ b/src/Microsoft.Identity.Abstractions/ApplicationOptions/CredentialDescription.cs
@@ -347,7 +347,7 @@ namespace Microsoft.Identity.Abstractions
                     CredentialSource.StoreWithDistinguishedName => CertificateDistinguishedName,
                     CredentialSource.Certificate or CredentialSource.Base64Encoded => Base64EncodedValue,
                     CredentialSource.SignedAssertionFromManagedIdentity => ManagedIdentityClientId,
-                    CredentialSource.ClientSecret => ClientSecret,
+                    CredentialSource.ClientSecret => "***",
                     _ => null,
                 };
             }

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/net462/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/net462/PublicAPI.Shipped.txt
@@ -248,3 +248,5 @@ virtual Microsoft.Identity.Abstractions.IdentityApplicationOptions.Authority.get
 virtual Microsoft.Identity.Abstractions.IdentityApplicationOptions.Authority.set -> void
 Microsoft.Identity.Abstractions.AcquireTokenOptions.ExtraParameters.get -> System.Collections.Generic.IDictionary<string!, object!>?
 Microsoft.Identity.Abstractions.AcquireTokenOptions.ExtraParameters.set -> void
+Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions.AppHomeTenantId.get -> string?
+Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions.AppHomeTenantId.set -> void

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/net462/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/net462/PublicAPI.Unshipped.txt
@@ -1,3 +1,1 @@
 #nullable enable
-Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions.AppHomeTenantId.get -> string?
-Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions.AppHomeTenantId.set -> void

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -276,4 +276,7 @@ virtual Microsoft.Identity.Abstractions.IdentityApplicationOptions.Authority.get
 virtual Microsoft.Identity.Abstractions.IdentityApplicationOptions.Authority.set -> void
 Microsoft.Identity.Abstractions.AcquireTokenOptions.ExtraParameters.get -> System.Collections.Generic.IDictionary<string!, object!>?
 Microsoft.Identity.Abstractions.AcquireTokenOptions.ExtraParameters.set -> void
+Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions.AppHomeTenantId.get -> string?
+Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions.AppHomeTenantId.set -> void
+
 

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,1 @@
 #nullable enable
-Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions.AppHomeTenantId.get -> string?
-Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions.AppHomeTenantId.set -> void

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -248,3 +248,5 @@ virtual Microsoft.Identity.Abstractions.IdentityApplicationOptions.Authority.get
 virtual Microsoft.Identity.Abstractions.IdentityApplicationOptions.Authority.set -> void
 Microsoft.Identity.Abstractions.AcquireTokenOptions.ExtraParameters.get -> System.Collections.Generic.IDictionary<string!, object!>?
 Microsoft.Identity.Abstractions.AcquireTokenOptions.ExtraParameters.set -> void
+Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions.AppHomeTenantId.get -> string?
+Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions.AppHomeTenantId.set -> void

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,1 @@
 #nullable enable
-Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions.AppHomeTenantId.get -> string?
-Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions.AppHomeTenantId.set -> void

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.1/PublicAPI.Shipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.1/PublicAPI.Shipped.txt
@@ -252,3 +252,5 @@ virtual Microsoft.Identity.Abstractions.IdentityApplicationOptions.Authority.get
 virtual Microsoft.Identity.Abstractions.IdentityApplicationOptions.Authority.set -> void
 Microsoft.Identity.Abstractions.AcquireTokenOptions.ExtraParameters.get -> System.Collections.Generic.IDictionary<string!, object!>?
 Microsoft.Identity.Abstractions.AcquireTokenOptions.ExtraParameters.set -> void
+Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions.AppHomeTenantId.get -> string?
+Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions.AppHomeTenantId.set -> void

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
@@ -1,3 +1,1 @@
 #nullable enable
-Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions.AppHomeTenantId.get -> string?
-Microsoft.Identity.Abstractions.MicrosoftIdentityApplicationOptions.AppHomeTenantId.set -> void

--- a/test/Microsoft.Identity.Abstractions.Tests/CredentialDescriptionTest.cs
+++ b/test/Microsoft.Identity.Abstractions.Tests/CredentialDescriptionTest.cs
@@ -196,7 +196,7 @@ namespace Microsoft.Identity.Abstractions.ApplicationOptions.Tests
 
             Assert.Equal(CredentialType.Secret, credentialDescription.CredentialType);
             Assert.Null(credentialDescription.Container);
-            Assert.Equal(credentialDescription.ClientSecret, credentialDescription.ReferenceOrValue);
+            Assert.Equal("***", credentialDescription.ReferenceOrValue);
         }
 
         [Fact]
@@ -426,14 +426,23 @@ namespace Microsoft.Identity.Abstractions.ApplicationOptions.Tests
         }
 
         // Ref/Value only
-        [Theory]
-        [InlineData(CredentialSource.ClientSecret)]
-        [InlineData(CredentialSource.SignedAssertionFromManagedIdentity)]
-        public void TestValueOrReference(CredentialSource credentialSource)
+        [Fact]
+        public void TestValueOrReferenceForSignedAssertionManagedIdentity()
         {
-            CredentialDescription credentialDescription = new CredentialDescription { SourceType = credentialSource };
+            CredentialDescription credentialDescription = new CredentialDescription 
+            { SourceType = CredentialSource.SignedAssertionFromManagedIdentity };
             credentialDescription.ReferenceOrValue = "referenceOrValue";
             Assert.Equal("referenceOrValue", credentialDescription.ReferenceOrValue);
+        }
+
+        // Ref/Value only
+        [Fact]
+        public void TestValueOrReferenceForClientSecret()
+        {
+            CredentialDescription credentialDescription = new CredentialDescription
+            { SourceType = CredentialSource.ClientSecret };
+            credentialDescription.ReferenceOrValue = "referenceOrValue";
+            Assert.Equal("***", credentialDescription.ReferenceOrValue);
         }
 
         [Theory]


### PR DESCRIPTION
# Fix #147

- Fixes #147. This is a desired behavioral change when reading the "ReferenceOrValue" in the case of ClientSecret.
- Updates the public API (that should have been updated earlier)
- Update the library version number to the next version.

This does not require changes to the consuming libraries. Unified build (20250121.2) started to confirm.
