### PR TITLE
Adding ICustomSignedAssertionProvider

### DIFF
--- a/src/Microsoft.Identity.Abstractions/ApplicationOptions/ICustomSignedAssertionProvider.cs
+++ b/src/Microsoft.Identity.Abstractions/ApplicationOptions/ICustomSignedAssertionProvider.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Microsoft.Identity.Abstractions
+{
+    /// <summary>
+    /// Interface to implement loading of a custom signed assertion providers.
+    /// </summary>
+    public interface ICustomSignedAssertionProvider : ICredentialSourceLoader
+    {
+        /// <summary>
+        /// Configuration friendly name of the custom signed assertion provider as it
+        /// will appear in the <see cref="CredentialDescription.CustomSignedAssertionProviderName"/>
+        /// Can be <c>null</c> in which case developers will need to pass-in the fully
+        /// qualified name of the implementing class.
+        /// </summary>
+        abstract string Name { get; }
+    }
+}

--- a/src/Microsoft.Identity.Abstractions/ApplicationOptions/ICustomSignedAssertionProvider.cs
+++ b/src/Microsoft.Identity.Abstractions/ApplicationOptions/ICustomSignedAssertionProvider.cs
@@ -8,7 +8,7 @@ using System.Text;
 namespace Microsoft.Identity.Abstractions
 {
     /// <summary>
-    /// Interface to implement loading of a custom signed assertion providers.
+    /// Interface to implement loading of a custom signed assertion provider.
     /// </summary>
     public interface ICustomSignedAssertionProvider : ICredentialSourceLoader
     {

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/net462/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/net462/PublicAPI.Unshipped.txt
@@ -4,3 +4,5 @@ Microsoft.Identity.Abstractions.CredentialDescription.CustomSignedAssertionProvi
 Microsoft.Identity.Abstractions.CredentialDescription.CustomSignedAssertionProviderName.get -> string?
 Microsoft.Identity.Abstractions.CredentialDescription.CustomSignedAssertionProviderName.set -> void
 Microsoft.Identity.Abstractions.CredentialSource.CustomSignedAssertion = 11 -> Microsoft.Identity.Abstractions.CredentialSource
+Microsoft.Identity.Abstractions.ICustomSignedAssertionProvider
+Microsoft.Identity.Abstractions.ICustomSignedAssertionProvider.Name.get -> string!

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -4,3 +4,5 @@ Microsoft.Identity.Abstractions.CredentialDescription.CustomSignedAssertionProvi
 Microsoft.Identity.Abstractions.CredentialDescription.CustomSignedAssertionProviderName.get -> string?
 Microsoft.Identity.Abstractions.CredentialDescription.CustomSignedAssertionProviderName.set -> void
 Microsoft.Identity.Abstractions.CredentialSource.CustomSignedAssertion = 11 -> Microsoft.Identity.Abstractions.CredentialSource
+Microsoft.Identity.Abstractions.ICustomSignedAssertionProvider
+Microsoft.Identity.Abstractions.ICustomSignedAssertionProvider.Name.get -> string!

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -4,3 +4,5 @@ Microsoft.Identity.Abstractions.CredentialDescription.CustomSignedAssertionProvi
 Microsoft.Identity.Abstractions.CredentialDescription.CustomSignedAssertionProviderName.get -> string?
 Microsoft.Identity.Abstractions.CredentialDescription.CustomSignedAssertionProviderName.set -> void
 Microsoft.Identity.Abstractions.CredentialSource.CustomSignedAssertion = 11 -> Microsoft.Identity.Abstractions.CredentialSource
+Microsoft.Identity.Abstractions.ICustomSignedAssertionProvider
+Microsoft.Identity.Abstractions.ICustomSignedAssertionProvider.Name.get -> string!

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
@@ -4,3 +4,5 @@ Microsoft.Identity.Abstractions.CredentialDescription.CustomSignedAssertionProvi
 Microsoft.Identity.Abstractions.CredentialDescription.CustomSignedAssertionProviderName.get -> string?
 Microsoft.Identity.Abstractions.CredentialDescription.CustomSignedAssertionProviderName.set -> void
 Microsoft.Identity.Abstractions.CredentialSource.CustomSignedAssertion = 11 -> Microsoft.Identity.Abstractions.CredentialSource
+Microsoft.Identity.Abstractions.ICustomSignedAssertionProvider
+Microsoft.Identity.Abstractions.ICustomSignedAssertionProvider.Name.get -> string!

--- a/test/Microsoft.Identity.Abstractions.Tests/CustomSignedAssertionProviderTests.cs
+++ b/test/Microsoft.Identity.Abstractions.Tests/CustomSignedAssertionProviderTests.cs
@@ -24,7 +24,6 @@ namespace Microsoft.Identity.Abstractions.Tests
             // Assert
             Assert.Equal(testProvider, name);
             Assert.Equal(expectedCredentialSource, credSource);
-
         }
     }
 

--- a/test/Microsoft.Identity.Abstractions.Tests/CustomSignedAssertionProviderTests.cs
+++ b/test/Microsoft.Identity.Abstractions.Tests/CustomSignedAssertionProviderTests.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Microsoft.Identity.Abstractions.Tests
+{
+    public class CustomSignedAssertionProviderTests
+    {
+        [Fact]
+        public void CustomSignedAssertionProvider_ShouldReturnConfiguredName()
+        {
+            // Arrange
+            string testProvider = "TestProvider";
+            var expectedCredentialSource = CredentialSource.CustomSignedAssertion;
+            var mockProvider = new MockCustomSignedAssertionProvider(testProvider);
+            
+            // Act
+            var name = mockProvider.Name;
+            var credSource = mockProvider.CredentialSource;
+
+            // Assert
+            Assert.Equal(testProvider, name);
+            Assert.Equal(expectedCredentialSource, credSource);
+
+        }
+    }
+
+    internal class MockCustomSignedAssertionProvider(string name) : object(), ICustomSignedAssertionProvider
+    {
+        public string Name { get; set; } = name;
+
+        public CredentialSource CredentialSource => CredentialSource.CustomSignedAssertion;
+
+        public Task LoadIfNeededAsync(CredentialDescription credentialDescription, CredentialSourceLoaderParameters? parameters = null)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}


### PR DESCRIPTION
Addresses issue #153 adding the ICustomSignedAssertionProvider interface to the Microsoft.Identity.Abstractions namespace in order to support custom signed assertion provider extensibility.