### PR TITLE
Compute really unique ID for ClientCredentials

### DIFF
--- a/src/Microsoft.Identity.Abstractions/ApplicationOptions/CredentialDescription.cs
+++ b/src/Microsoft.Identity.Abstractions/ApplicationOptions/CredentialDescription.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System;
+using System.Buffers.Text;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
@@ -82,6 +83,10 @@ namespace Microsoft.Identity.Abstractions
                             {
                                 _cachedId = $"Certificate={Certificate.Thumbprint}";
                             }
+                            else
+                            {
+                                _cachedId = $"Certificate=null";
+                            }
                             break;
                         case CredentialSource.KeyVault:
                             _cachedId = $"CertificateFromKeyVault={KeyVaultUrl}/{KeyVaultCertificateName}";
@@ -135,7 +140,7 @@ namespace Microsoft.Identity.Abstractions
 #if !NET8_0_OR_GREATER
             using (SHA256 sha256 = SHA256.Create())
             {
-                digest = sha256.ComputeHash(Encoding.UTF8.GetBytes(secret));
+                digest = sha256.ComputeHash(Encoding.Unicode.GetBytes(secret));
             }
 #else
             digest = SHA256.HashData(Encoding.Unicode.GetBytes(secret));

--- a/src/Microsoft.Identity.Abstractions/ApplicationOptions/CredentialDescription.cs
+++ b/src/Microsoft.Identity.Abstractions/ApplicationOptions/CredentialDescription.cs
@@ -3,9 +3,7 @@
 
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.ComponentModel;
-using System.Globalization;
 using System.Security.Cryptography;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;

--- a/src/Microsoft.Identity.Abstractions/ApplicationOptions/CredentialDescription.cs
+++ b/src/Microsoft.Identity.Abstractions/ApplicationOptions/CredentialDescription.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using System;
-using System.Buffers.Text;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;

--- a/src/Microsoft.Identity.Abstractions/ApplicationOptions/ICustomSignedAssertionProvider.cs
+++ b/src/Microsoft.Identity.Abstractions/ApplicationOptions/ICustomSignedAssertionProvider.cs
@@ -1,10 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System;
-using System.Collections.Generic;
-using System.Text;
-
 namespace Microsoft.Identity.Abstractions
 {
     /// <summary>

--- a/src/Microsoft.Identity.Abstractions/ApplicationOptions/MicrosoftIdentityApplicationOptions.cs
+++ b/src/Microsoft.Identity.Abstractions/ApplicationOptions/MicrosoftIdentityApplicationOptions.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Collections.Generic;
-
 namespace Microsoft.Identity.Abstractions
 {
     /// <summary>

--- a/src/Microsoft.Identity.Abstractions/DownstreamApi/DownstreamApiOptionsReadOnlyHttpMethod.cs
+++ b/src/Microsoft.Identity.Abstractions/DownstreamApi/DownstreamApiOptionsReadOnlyHttpMethod.cs
@@ -1,8 +1,6 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using System.Net.Http;
-
 namespace Microsoft.Identity.Abstractions
 {
     /// <summary>

--- a/src/Microsoft.Identity.Abstractions/DownstreamApi/IDownstreamApi.HttpMethods.cs
+++ b/src/Microsoft.Identity.Abstractions/DownstreamApi/IDownstreamApi.HttpMethods.cs
@@ -6,7 +6,6 @@ using System.Net.Http;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Identity.Abstractions;
 
 #if NET8_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;

--- a/test/Microsoft.Identity.Abstractions.Tests/CredentialDescriptionIdTest.cs
+++ b/test/Microsoft.Identity.Abstractions.Tests/CredentialDescriptionIdTest.cs
@@ -1,3 +1,6 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
 using Microsoft.Identity.Abstractions;
 using System;
 using System.Collections.Generic;

--- a/test/Microsoft.Identity.Abstractions.Tests/CredentialDescriptionIdTest.cs
+++ b/test/Microsoft.Identity.Abstractions.Tests/CredentialDescriptionIdTest.cs
@@ -1,10 +1,8 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Microsoft.Identity.Abstractions;
 using System;
 using System.Collections.Generic;
-using System.ComponentModel;
 using System.Globalization;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
@@ -14,6 +12,8 @@ namespace Microsoft.Identity.Abstractions.Tests
 {
     public class CredentialDescriptionIdTest
     {
+        const string base64encoded = "MIIDDjCCAfagAwIBAgIQIo6M1+XYDbtDgY/Z3VcWOjANBgkqhkiG9w0BAQsFADAaMRgwFgYDVQQDDA9UZXN0Q2VydGlmaWNhdGUwHhcNMjUwMzI1MDExMTExWhcNMjYwMzI1MDEzMTExWjAaMRgwFgYDVQQDDA9UZXN0Q2VydGlmaWNhdGUwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQClI8k4uhi7yfdHHYq17MbWmGl2sdgTZ+yRserSQFLcAoVLkVppfwEeccuj6DQraQXhoXXLVk+DXgTx5+/pJTekNpv4arexGwTG2GztPDaiku188minJVDHB7sD6MqTBXqDrFMfEu4uZZmDRMTC3q+sNhiDpMG09NjH/OZnhab0ORu0lXDxoFKtZbYc1yK56eMsYqz2T+K8JkJejvMtuOq3ZERQSvhn+Ud400wUYTyi45D/5zKHrqw0Xyg9Q7Hl4g7GnBcWPWG8JGIseaLJFWyl5yXEQrR1s7S1RNmX+9/YbSV/JzSzicmM66aytwjI8VTLuoXEXXYdzZo0ZO0oxheRAgMBAAGjUDBOMA4GA1UdDwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBgEFBQcDAgYIKwYBBQUHAwEwHQYDVR0OBBYEFNQtVk+KmmYHqcdsH/jf305p/dh8MA0GCSqGSIb3DQEBCwUAA4IBAQBmUdRF8R3i3WJiEnxYSpgsdMZox1WrEpQugnLYEywmXqNify/M4qNvBpKVNOVVFmGg94V57D8SHbr77nIhyiwPUF3161MixJ+EO0bl+Iepu3GAQ6nbgnRtsbPhhmFIR5MWCQ7ekVaoxIbvWV/Jxha4ZoVyxLOcshRQaKfUZuzjZorhY0P4oXM7zVAw80btbP5nC5FucH0Z2kzIVwXDJsTKWeBXDSXm67hZ2wA4+B9NDDtRX6hxTT9wWmo6vlogfwGKUJJp+X6rs4jt59whms6himga0exf5k9A32+o8O8RJr0h/1gN6VWOcZeu+aBWH/ozuB/eG6hZMV0/oKvhbUki";
+        
         [Fact]
         public void NullSecretIdTest()
         {
@@ -28,8 +28,9 @@ namespace Microsoft.Identity.Abstractions.Tests
         [Fact]
         public void DisplayCredentialDescriptionIdsForAllSourceTypes()
         {
-            // Create a credential description for each SourceType
-            var credentialDescriptions = new Dictionary<CredentialSource, CredentialDescription>
+                // Create a credential description for each SourceType
+#pragma warning disable SYSLIB0026 // Type or member is obsolete
+                var credentialDescriptions = new Dictionary<CredentialSource, CredentialDescription>
                     {
                         // Certificate
                         {
@@ -37,7 +38,7 @@ namespace Microsoft.Identity.Abstractions.Tests
                             new CredentialDescription
                             {
                                 SourceType = CredentialSource.Certificate,
-                                Certificate = new X509Certificate2("C:\\Users\\jmprieur\\Downloads\\buildautomation-AzureADIdentityDivisionTestAgentCert-20230521.pfx"), // "path/to/certificate.pfx", "password"
+                                Certificate = new X509Certificate2(Convert.FromBase64String(base64encoded)), // "path/to/certificate.pfx"
                                 CertificatePassword = "password"
                             }
                         },
@@ -167,6 +168,7 @@ namespace Microsoft.Identity.Abstractions.Tests
                             }
                         }
                     };
+#pragma warning restore SYSLIB0026 // Type or member is obsolete
 
 #if DEBUG
             StringBuilder sb = new StringBuilder();

--- a/test/Microsoft.Identity.Abstractions.Tests/CredentialDescriptionIdTest.cs
+++ b/test/Microsoft.Identity.Abstractions.Tests/CredentialDescriptionIdTest.cs
@@ -1,0 +1,185 @@
+using Microsoft.Identity.Abstractions;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Globalization;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
+using Xunit;
+
+namespace Microsoft.Identity.Abstractions.Tests
+{
+    public class CredentialDescriptionIdTest
+    {
+        [Fact]
+        public void NullSecretIdTest()
+        {
+            var credentialDescription = new CredentialDescription
+            {
+                SourceType = CredentialSource.ClientSecret,
+                ClientSecret = null
+            };
+            Assert.Equal("ClientSecret=", credentialDescription.Id);
+        }
+
+        [Fact]
+        public void DisplayCredentialDescriptionIdsForAllSourceTypes()
+        {
+            // Create a credential description for each SourceType
+            var credentialDescriptions = new Dictionary<CredentialSource, CredentialDescription>
+                    {
+                        // Certificate
+                        {
+                            CredentialSource.Certificate,
+                            new CredentialDescription
+                            {
+                                SourceType = CredentialSource.Certificate,
+                                Certificate = new X509Certificate2("C:\\Users\\jmprieur\\Downloads\\buildautomation-AzureADIdentityDivisionTestAgentCert-20230521.pfx"), // "path/to/certificate.pfx", "password"
+                                CertificatePassword = "password"
+                            }
+                        },
+                        
+                        // KeyVault
+                        {
+                            CredentialSource.KeyVault,
+                            new CredentialDescription
+                            {
+                                SourceType = CredentialSource.KeyVault,
+                                KeyVaultUrl = "https://mykeyvault.vault.azure.net",
+                                KeyVaultCertificateName = "MyCertificate"
+                            }
+                        },
+                        
+                        // Base64Encoded
+                        {
+                            CredentialSource.Base64Encoded,
+                            new CredentialDescription
+                            {
+                                SourceType = CredentialSource.Base64Encoded,
+                                Base64EncodedValue = "MIIDHzCgegA.....r1n8Ta0="
+                            }
+                        },
+                        
+                        // Path
+                        {
+                            CredentialSource.Path,
+                            new CredentialDescription
+                            {
+                                SourceType = CredentialSource.Path,
+                                CertificateDiskPath = "c:\\temp\\Certificate.pfx",
+                                CertificatePassword = "password"
+                            }
+                        },
+                        
+                        // StoreWithThumbprint
+                        {
+                            CredentialSource.StoreWithThumbprint,
+                            new CredentialDescription
+                            {
+                                SourceType = CredentialSource.StoreWithThumbprint,
+                                CertificateStorePath = "CurrentUser/My",
+                                CertificateThumbprint = "962D129A...D18EFEB6961684"
+                            }
+                        },
+                        
+                        // StoreWithDistinguishedName
+                        {
+                            CredentialSource.StoreWithDistinguishedName,
+                            new CredentialDescription
+                            {
+                                SourceType = CredentialSource.StoreWithDistinguishedName,
+                                CertificateStorePath = "CurrentUser/My",
+                                CertificateDistinguishedName = "CN=WebAppCallingWebApiCert"
+                            }
+                        },
+                        
+                        // ClientSecret
+                        {
+                            CredentialSource.ClientSecret,
+                            new CredentialDescription
+                            {
+                                SourceType = CredentialSource.ClientSecret,
+                                ClientSecret = "MyClientSecret"
+                            }
+                        },
+                        
+                        // SignedAssertionFromManagedIdentity
+                        {
+                            CredentialSource.SignedAssertionFromManagedIdentity,
+                            new CredentialDescription
+                            {
+                                SourceType = CredentialSource.SignedAssertionFromManagedIdentity,
+                                ManagedIdentityClientId = "12345"
+                            }
+                        },
+                        
+                        // SignedAssertionFilePath
+                        {
+                            CredentialSource.SignedAssertionFilePath,
+                            new CredentialDescription
+                            {
+                                SourceType = CredentialSource.SignedAssertionFilePath,
+                                SignedAssertionFileDiskPath = "c:/path.signedAssertion"
+                            }
+                        },
+                        
+                        // SignedAssertionFromVault
+                        {
+                            CredentialSource.SignedAssertionFromVault,
+                            new CredentialDescription
+                            {
+                                SourceType = CredentialSource.SignedAssertionFromVault,
+                                KeyVaultCertificateName = "somename"
+                            }
+                        },
+                        
+                        // AutoDecryptKeys
+                        {
+                            CredentialSource.AutoDecryptKeys,
+                            new CredentialDescription
+                            {
+                                SourceType = CredentialSource.AutoDecryptKeys,
+                                DecryptKeysAuthenticationOptions = new AuthorizationHeaderProviderOptions
+                                {
+                                    ProtocolScheme = "Bearer",
+                                    AcquireTokenOptions = new AcquireTokenOptions
+                                    {
+                                        Tenant = "mytenant.onmicrosoftonline.com"
+                                    }
+                                }
+                            }
+                        },
+                        
+                        // CustomSignedAssertion
+                        {
+                            CredentialSource.CustomSignedAssertion,
+                            new CredentialDescription
+                            {
+                                SourceType = CredentialSource.CustomSignedAssertion,
+                                CustomSignedAssertionProviderName = "MyCustomProvider",
+                                CustomSignedAssertionProviderData = new Dictionary<string, object>
+                                {
+                                    { "MyCustomProviderData_Key", "MyCustomProviderData_Data" }
+                                }
+                            }
+                        }
+                    };
+
+#if DEBUG
+            StringBuilder sb = new StringBuilder();
+            foreach (var kvp in credentialDescriptions)
+            {
+                sb.AppendLine(string.Format(CultureInfo.InvariantCulture, $"Id: {kvp.Value.Id}"));
+            }
+            string allDescriptions = sb.ToString();
+#endif
+
+            // Assertions to make sure each credential description has an Id
+            foreach (var credentialDescription in credentialDescriptions.Values)
+            {
+                Assert.NotNull(credentialDescription.Id);
+                Assert.Contains(credentialDescription.SourceType.ToString(), credentialDescription.Id, StringComparison.Ordinal);
+            }
+        }
+    }
+}

--- a/test/Microsoft.Identity.Abstractions.Tests/CredentialDescriptionTest.cs
+++ b/test/Microsoft.Identity.Abstractions.Tests/CredentialDescriptionTest.cs
@@ -398,7 +398,7 @@ namespace Microsoft.Identity.Abstractions.ApplicationOptions.Tests
         {
             CredentialDescription credentialDescription = new();
             credentialDescription.Certificate = null;
-            Assert.Null(credentialDescription.Id);
+            Assert.NotNull(credentialDescription.Id);
         }
 
         [Fact]

--- a/test/Microsoft.Identity.Abstractions.Tests/CredentialDescriptionTest.cs
+++ b/test/Microsoft.Identity.Abstractions.Tests/CredentialDescriptionTest.cs
@@ -3,7 +3,6 @@
 
 using Xunit;
 using System.Collections.Generic;
-using System.Security.Cryptography.X509Certificates;
 using System;
 
 namespace Microsoft.Identity.Abstractions.ApplicationOptions.Tests


### PR DESCRIPTION
# Fix163

## Description

- Removes the container and value properties that are no longer needed since IdWeb 2
- Compute the ID directly, based on the credential type, making sensitive data is redacted
