### PR TITLE
Fix #168

### DIFF
--- a/src/Microsoft.Identity.Abstractions/ApplicationOptions/MicrosoftEntraApplicationOptions.cs
+++ b/src/Microsoft.Identity.Abstractions/ApplicationOptions/MicrosoftEntraApplicationOptions.cs
@@ -13,7 +13,7 @@ namespace Microsoft.Identity.Abstractions
         private string? _authority;
 
         /// <summary>
-        /// Gets or sets the name of the options. T
+        /// Gets or sets the name of the options.
         /// This can be used to associate the options with a named options in 
         /// the .NET IOptionsMonitor or IOptionsSnapshot (or ASP.NET Core authentication schemes)
         /// </summary>

--- a/src/Microsoft.Identity.Abstractions/ApplicationOptions/MicrosoftEntraApplicationOptions.cs
+++ b/src/Microsoft.Identity.Abstractions/ApplicationOptions/MicrosoftEntraApplicationOptions.cs
@@ -13,6 +13,13 @@ namespace Microsoft.Identity.Abstractions
         private string? _authority;
 
         /// <summary>
+        /// Gets or sets the name of the options. T
+        /// This can be used to associate the options with a named options in 
+        /// the .NET IOptionsMonitor or IOptionsSnapshot (or ASP.NET Core authentication schemes)
+        /// </summary>
+        public string? Name { get; set; }
+
+        /// <summary>
         /// Gets or sets the Azure Active Directory instance, e.g. <c>"https://login.microsoftonline.com/"</c>.
         /// </summary>
         public string? Instance { get; set; }

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/net462/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/net462/PublicAPI.Unshipped.txt
@@ -9,6 +9,8 @@ Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions.ClientCapabilit
 Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions.Instance.get -> string?
 Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions.Instance.set -> void
 Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions.MicrosoftEntraApplicationOptions() -> void
+Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions.Name.get -> string?
+Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions.Name.set -> void
 Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions.SendX5C.get -> bool
 Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions.SendX5C.set -> void
 Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions.TenantId.get -> string?

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -9,6 +9,8 @@ Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions.ClientCapabilit
 Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions.Instance.get -> string?
 Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions.Instance.set -> void
 Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions.MicrosoftEntraApplicationOptions() -> void
+Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions.Name.get -> string?
+Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions.Name.set -> void
 Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions.SendX5C.get -> bool
 Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions.SendX5C.set -> void
 Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions.TenantId.get -> string?

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -9,6 +9,8 @@ Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions.ClientCapabilit
 Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions.Instance.get -> string?
 Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions.Instance.set -> void
 Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions.MicrosoftEntraApplicationOptions() -> void
+Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions.Name.get -> string?
+Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions.Name.set -> void
 Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions.SendX5C.get -> bool
 Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions.SendX5C.set -> void
 Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions.TenantId.get -> string?

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
@@ -9,6 +9,8 @@ Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions.ClientCapabilit
 Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions.Instance.get -> string?
 Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions.Instance.set -> void
 Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions.MicrosoftEntraApplicationOptions() -> void
+Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions.Name.get -> string?
+Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions.Name.set -> void
 Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions.SendX5C.get -> bool
 Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions.SendX5C.set -> void
 Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions.TenantId.get -> string?

--- a/test/Microsoft.Identity.Abstractions.Tests/MicrosoftIdentityApplicationOptionsTests.cs
+++ b/test/Microsoft.Identity.Abstractions.Tests/MicrosoftIdentityApplicationOptionsTests.cs
@@ -20,12 +20,13 @@ namespace Microsoft.Identity.Abstractions.ApplicationOptions.Tests
         private CredentialDescription decryptCert = new CredentialDescription { SourceType = CredentialSource.Base64Encoded, Base64EncodedValue = "0123" };
         private string[] audiences = new[] { "https://myapi", clientId };
         private const string appHomeTenantId = "this-is-a-tenant-guid";
-
+        private const string name = "OptionsName";
         [Fact]
         public void MicrosoftIdentityApplicationOptionsProperties()
         {
             MicrosoftIdentityApplicationOptions microsoftIdentityApplicationOptions = new()
             {
+                Name = name,
                 Instance = instance,
                 TenantId = tenant,
                 AppHomeTenantId = appHomeTenantId,
@@ -58,6 +59,7 @@ namespace Microsoft.Identity.Abstractions.ApplicationOptions.Tests
             
             microsoftIdentityApplicationOptions.Authority = "https://login.microsoftonline.com/common";
 
+            Assert.Equal(name, microsoftIdentityApplicationOptions.Name);
             Assert.Equal("https://login.microsoftonline.com/common", microsoftIdentityApplicationOptions.Authority);
             Assert.Equal(clientId, microsoftIdentityApplicationOptions.ClientId);
             Assert.Equal(tenant, microsoftIdentityApplicationOptions.TenantId);


### PR DESCRIPTION
# Fix #168
Add a Name property to MicrosoftEntraIdApplicationOptions so that we can associate them with ASP.NET Core authentication schemes or other options name. See issue