### PR TITLE
Add a new generic IAuthorizationHeaderProvider

### DIFF
--- a/src/Microsoft.Identity.Abstractions/DownstreamApi/IAuthorizationHeaderProvider_T.cs
+++ b/src/Microsoft.Identity.Abstractions/DownstreamApi/IAuthorizationHeaderProvider_T.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+using System.Security.Claims;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Microsoft.Identity.Abstractions
+{
+    /// <summary>
+    /// <inheritdoc cref="IAuthorizationHeaderProvider"/>
+    /// </summary>
+    /// <typeparam name="TResult">The result type.</typeparam>
+    public interface IAuthorizationHeaderProvider<TResult>
+    {
+        /// <inheritdoc cref="IAuthorizationHeaderProvider.CreateAuthorizationHeaderAsync"/>
+        /// <param name="downstreamApiOptions">
+        /// The options containing information about the API
+        /// to be called and token acquisition settings.
+        /// Use <see cref="DownstreamApiOptions.Scopes"/> to request scope(s)
+        /// for the authorization header.
+        /// </param>
+        /// <param name="claimsPrincipal">
+        /// <inheritdoc cref="IAuthorizationHeaderProvider.CreateAuthorizationHeaderAsync"/>
+        /// </param>
+        /// <param name="cancellationToken">
+        /// <inheritdoc cref="IAuthorizationHeaderProvider.CreateAuthorizationHeaderAsync"/>
+        /// </param>        
+        Task<TResult> CreateAuthorizationHeaderAsync(
+            DownstreamApiOptions downstreamApiOptions,
+            ClaimsPrincipal? claimsPrincipal = null,
+            CancellationToken cancellationToken = default);
+    }
+}

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/net462/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/net462/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 #nullable enable
+Microsoft.Identity.Abstractions.IAuthorizationHeaderProvider<TResult>
+Microsoft.Identity.Abstractions.IAuthorizationHeaderProvider<TResult>.CreateAuthorizationHeaderAsync(Microsoft.Identity.Abstractions.DownstreamApiOptions! downstreamApiOptions, System.Security.Claims.ClaimsPrincipal? claimsPrincipal = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TResult>!
 Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions
 Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions.AppHomeTenantId.get -> string?
 Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions.AppHomeTenantId.set -> void

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 #nullable enable
+Microsoft.Identity.Abstractions.IAuthorizationHeaderProvider<TResult>
+Microsoft.Identity.Abstractions.IAuthorizationHeaderProvider<TResult>.CreateAuthorizationHeaderAsync(Microsoft.Identity.Abstractions.DownstreamApiOptions! downstreamApiOptions, System.Security.Claims.ClaimsPrincipal? claimsPrincipal = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TResult>!
 Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions
 Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions.AppHomeTenantId.get -> string?
 Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions.AppHomeTenantId.set -> void

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 #nullable enable
+Microsoft.Identity.Abstractions.IAuthorizationHeaderProvider<TResult>
+Microsoft.Identity.Abstractions.IAuthorizationHeaderProvider<TResult>.CreateAuthorizationHeaderAsync(Microsoft.Identity.Abstractions.DownstreamApiOptions! downstreamApiOptions, System.Security.Claims.ClaimsPrincipal? claimsPrincipal = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TResult>!
 Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions
 Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions.AppHomeTenantId.get -> string?
 Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions.AppHomeTenantId.set -> void

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 #nullable enable
+Microsoft.Identity.Abstractions.IAuthorizationHeaderProvider<TResult>
+Microsoft.Identity.Abstractions.IAuthorizationHeaderProvider<TResult>.CreateAuthorizationHeaderAsync(Microsoft.Identity.Abstractions.DownstreamApiOptions! downstreamApiOptions, System.Security.Claims.ClaimsPrincipal? claimsPrincipal = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TResult>!
 Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions
 Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions.AppHomeTenantId.get -> string?
 Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions.AppHomeTenantId.set -> void


### PR DESCRIPTION
This allows the implementor to specialize the return type

# Add a new generic IAuthorizationHeaderProvider
<!-- Thank you for submitting a pull request to our repo. -->

<!-- If this is your first PR in the Microsoft.Identity.Abstractions repo, please run through the checklist
below to ensure a smooth review and merge process for your PR. -->

- [x] You've read the [Contributor Guide](https://github.com/AzureAD/microsoft-identity-web/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/AzureAD/microsoft-identity-web/blob/master/CODE_OF_CONDUCT.md).
- [ ] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

<!-- Once all that is done, you're ready to go. Open the PR with the content below. -->

Summary of the changes (Less than 80 chars)

## Description

Adds a new interface, IAuthorizationHeaderProvider<TResult>

Fixes #172 
