### PR TITLE
Add ClientCapabilities support to AcquireTokenOptions (+tests)

### DIFF
--- a/src/Microsoft.Identity.Abstractions/PublicAPI/net462/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/net462/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 #nullable enable
+Microsoft.Identity.Abstractions.AcquireTokenOptions.ClientCapabilities.get -> System.Collections.Generic.IEnumerable<string!>?
+Microsoft.Identity.Abstractions.AcquireTokenOptions.ClientCapabilities.set -> void
 Microsoft.Identity.Abstractions.IAuthorizationHeaderProvider<TResult>
 Microsoft.Identity.Abstractions.IAuthorizationHeaderProvider<TResult>.CreateAuthorizationHeaderAsync(Microsoft.Identity.Abstractions.DownstreamApiOptions! downstreamApiOptions, System.Security.Claims.ClaimsPrincipal? claimsPrincipal = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TResult>!
 Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 #nullable enable
+Microsoft.Identity.Abstractions.AcquireTokenOptions.ClientCapabilities.get -> System.Collections.Generic.IEnumerable<string!>?
+Microsoft.Identity.Abstractions.AcquireTokenOptions.ClientCapabilities.set -> void
 Microsoft.Identity.Abstractions.CredentialDescriptionJsonConverter
 Microsoft.Identity.Abstractions.CredentialDescriptionJsonConverter.CredentialDescriptionJsonConverter() -> void
 Microsoft.Identity.Abstractions.IAuthorizationHeaderProvider<TResult>

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/net9.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/net9.0/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 #nullable enable
+Microsoft.Identity.Abstractions.AcquireTokenOptions.ClientCapabilities.get -> System.Collections.Generic.IEnumerable<string!>?
+Microsoft.Identity.Abstractions.AcquireTokenOptions.ClientCapabilities.set -> void
 Microsoft.Identity.Abstractions.CredentialDescriptionJsonConverter
 Microsoft.Identity.Abstractions.CredentialDescriptionJsonConverter.CredentialDescriptionJsonConverter() -> void
 Microsoft.Identity.Abstractions.IAuthorizationHeaderProvider<TResult>

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 #nullable enable
+Microsoft.Identity.Abstractions.AcquireTokenOptions.ClientCapabilities.get -> System.Collections.Generic.IEnumerable<string!>?
+Microsoft.Identity.Abstractions.AcquireTokenOptions.ClientCapabilities.set -> void
 Microsoft.Identity.Abstractions.IAuthorizationHeaderProvider<TResult>
 Microsoft.Identity.Abstractions.IAuthorizationHeaderProvider<TResult>.CreateAuthorizationHeaderAsync(Microsoft.Identity.Abstractions.DownstreamApiOptions! downstreamApiOptions, System.Security.Claims.ClaimsPrincipal? claimsPrincipal = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TResult>!
 Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 #nullable enable
+Microsoft.Identity.Abstractions.AcquireTokenOptions.ClientCapabilities.get -> System.Collections.Generic.IEnumerable<string!>?
+Microsoft.Identity.Abstractions.AcquireTokenOptions.ClientCapabilities.set -> void
 Microsoft.Identity.Abstractions.IAuthorizationHeaderProvider<TResult>
 Microsoft.Identity.Abstractions.IAuthorizationHeaderProvider<TResult>.CreateAuthorizationHeaderAsync(Microsoft.Identity.Abstractions.DownstreamApiOptions! downstreamApiOptions, System.Security.Claims.ClaimsPrincipal? claimsPrincipal = null, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken)) -> System.Threading.Tasks.Task<TResult>!
 Microsoft.Identity.Abstractions.MicrosoftEntraApplicationOptions

--- a/src/Microsoft.Identity.Abstractions/TokenAcquisition/AcquireTokenOptions.cs
+++ b/src/Microsoft.Identity.Abstractions/TokenAcquisition/AcquireTokenOptions.cs
@@ -41,6 +41,7 @@ namespace Microsoft.Identity.Abstractions
             LongRunningWebApiSessionKey = other.LongRunningWebApiSessionKey;
             Tenant = other.Tenant;
             UserFlow = other.UserFlow;
+            ClientCapabilities = other.ClientCapabilities;
         }
 
         /// <summary>
@@ -81,6 +82,11 @@ namespace Microsoft.Identity.Abstractions
         /// CA Auth context</see>
         /// </summary>
         public string? Claims { get; set; }
+
+        /// <summary>
+        /// A list of client capabilities to be sent in the request to the STS "/token" endpoint.
+        /// </summary>
+        public IEnumerable<string>? ClientCapabilities { get; set; }
 
         /// <summary>
         /// Federated Managed Identity (FMI) sub-path.

--- a/test/Microsoft.Identity.Abstractions.Tests/AcquireTokenResultTests.cs
+++ b/test/Microsoft.Identity.Abstractions.Tests/AcquireTokenResultTests.cs
@@ -8,8 +8,6 @@ namespace Microsoft.Identity.Abstractions.TokenAcquisition.Tests
 {
     public class AcquireTokenResultTests
     {
-        private static readonly string[] _caps = new[] { "cp1", "someExperimentalFlag" };
-
         [Fact]
         public void TestAcquireTokenResult()
         {

--- a/test/Microsoft.Identity.Abstractions.Tests/AcquireTokenResultTests.cs
+++ b/test/Microsoft.Identity.Abstractions.Tests/AcquireTokenResultTests.cs
@@ -8,6 +8,8 @@ namespace Microsoft.Identity.Abstractions.TokenAcquisition.Tests
 {
     public class AcquireTokenResultTests
     {
+        private static readonly string[] _caps = new[] { "cp1", "someExperimentalFlag" };
+
         [Fact]
         public void TestAcquireTokenResult()
         {

--- a/test/Microsoft.Identity.Abstractions.Tests/AquireTokenOptionsTests.cs
+++ b/test/Microsoft.Identity.Abstractions.Tests/AquireTokenOptionsTests.cs
@@ -1,6 +1,7 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Linq;
 using Xunit;
 
 namespace Microsoft.Identity.Abstractions.Tests
@@ -92,6 +93,35 @@ namespace Microsoft.Identity.Abstractions.Tests
 
             Assert.NotNull(acquireTokenOptions.FmiPath);
             Assert.Equal("/example.org/service/my-service", acquireTokenOptions.FmiPath);
+        }
+
+        [Fact]
+        public void ClientCapabilities_ArePreservedAndCloneable()
+        {
+            /*
+            // <clientcapabilities_json>
+            {
+              "AcquireTokenOptions": {
+                "ClientCapabilities": [ "cp1", "cp2" ]
+              }
+            }
+            // </clientcapabilities_json>
+            */
+
+            // <clientcapabilities_csharp>
+            var original = new AcquireTokenOptions
+            {
+                ClientCapabilities = [ "cp1", "cp2" ]
+            };
+            // </clientcapabilities_csharp>
+
+            Assert.True(original.ClientCapabilities!.SequenceEqual(["cp1", "cp2" ]));
+
+            // Ensure Clone() keeps the same capabilities but returns a new instance
+            var clone = original.Clone();
+
+            Assert.NotSame(original, clone);
+            Assert.True(clone.ClientCapabilities!.SequenceEqual(original.ClientCapabilities));
         }
     }
 }

--- a/test/Microsoft.Identity.Abstractions.Tests/DownstreamApiTests.cs
+++ b/test/Microsoft.Identity.Abstractions.Tests/DownstreamApiTests.cs
@@ -40,7 +40,8 @@ namespace Microsoft.Identity.Abstractions.DownstreamApi.Tests
                     PopPublicKey = "PopKey",
                     PopClaim = "jwkClaim",
                     Tenant = "domain.com",
-                    UserFlow = "susi"
+                    UserFlow = "susi",
+                    ClientCapabilities = [ "cp1", "cp2" ]
 
                 },
                 BaseUrl = "https://apitocall.domain.com",
@@ -92,12 +93,13 @@ namespace Microsoft.Identity.Abstractions.DownstreamApi.Tests
             Assert.Equal(downstreamApiOptions.AcquireTokenOptions.PopClaim, downstreamApiClone.AcquireTokenOptions.PopClaim);
             Assert.Equal(downstreamApiOptions.AcquireTokenOptions.Tenant, downstreamApiClone.AcquireTokenOptions.Tenant);
             Assert.Equal(downstreamApiOptions.AcquireTokenOptions.UserFlow, downstreamApiClone.AcquireTokenOptions.UserFlow);
+            Assert.Equal(downstreamApiOptions.AcquireTokenOptions.ClientCapabilities, downstreamApiClone.AcquireTokenOptions.ClientCapabilities ?? []);
             Assert.Equal("application/json", downstreamApiClone.AcceptHeader);
             Assert.Equal("application/json", downstreamApiClone.ContentType);
 
             // If this fails, think of also adding a line to test the new property
             Assert.Equal(12, typeof(DownstreamApiOptions).GetProperties().Length);
-            Assert.Equal(15, typeof(AcquireTokenOptions).GetProperties().Length);
+            Assert.Equal(16, typeof(AcquireTokenOptions).GetProperties().Length);
 
             DownstreamApiOptionsReadOnlyHttpMethod options = new DownstreamApiOptionsReadOnlyHttpMethod(downstreamApiOptions, HttpMethod.Delete.ToString());
             Assert.Equal(HttpMethod.Delete.ToString(), options.HttpMethod);


### PR DESCRIPTION
# DRAFT: Add ClientCapabilities support to AcquireTokenOptions (+tests) for feedback

- [x] You've read the [Contributor Guide](https://github.com/AzureAD/microsoft-identity-web/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/AzureAD/microsoft-identity-web/blob/master/CODE_OF_CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

## Description

This pull request introduces a new `ClientCapabilities` property to the `AcquireTokenOptions` class and ensures it is properly integrated, tested, and documented across multiple frameworks and test cases. The most important changes include adding the property, updating public APIs, and implementing corresponding unit tests.

### Feature Addition: `ClientCapabilities` Property

* Added a new `ClientCapabilities` property to the `AcquireTokenOptions` class, allowing a list of client capabilities to be sent in requests to the STS `/token` endpoint. The property includes getter and setter methods. (`src/Microsoft.Identity.Abstractions/TokenAcquisition/AcquireTokenOptions.cs`, [src/Microsoft.Identity.Abstractions/TokenAcquisition/AcquireTokenOptions.csR86-R90](diffhunk://#diff-ec4ddb96f7e267f50bf1dfefccf5f3fed846b14699c6e5f400b43b9d42e1df91R86-R90))
* Updated the constructor of `AcquireTokenOptions` to copy the `ClientCapabilities` property when cloning an instance. (`src/Microsoft.Identity.Abstractions/TokenAcquisition/AcquireTokenOptions.cs`, [src/Microsoft.Identity.Abstractions/TokenAcquisition/AcquireTokenOptions.csR44](diffhunk://#diff-ec4ddb96f7e267f50bf1dfefccf5f3fed846b14699c6e5f400b43b9d42e1df91R44))

### Public API Updates

* Added the `ClientCapabilities` property to the public API files for multiple frameworks (`net462`, `netstandard2.0`, `netstandard2.1`, `net8.0`, `net9.0`). (`src/Microsoft.Identity.Abstractions/PublicAPI/.../PublicAPI.Unshipped.txt`, [[1]](diffhunk://#diff-665d8e1e8d25c7ac9b61223c9cff890222480bc79329bf8a7469452cb94922ccR2-R3) [[2]](diffhunk://#diff-1e5cc1a3a6eb36ad385dfffc178e60c26160ff9a6021fb4ae200539d1f644b77R2-R3)

### Unit Tests and Validation

* Added a new test case `ClientCapabilities_ArePreservedAndCloneable` to validate that the `ClientCapabilities` property is preserved during cloning and behaves as expected. (`test/Microsoft.Identity.Abstractions.Tests/AquireTokenOptionsTests.cs`, [test/Microsoft.Identity.Abstractions.Tests/AquireTokenOptionsTests.csR97-R125](diffhunk://#diff-75bc0844ca98436b6d80f0b9d993dd6fc37f881b7b0f158c1a4019782a3ce360R97-R125))
* Updated the `CloneClonesAllProperties` test to include validation for the `ClientCapabilities` property. (`test/Microsoft.Identity.Abstractions.Tests/DownstreamApiTests.cs`, [[1]](diffhunk://#diff-d7ffbc202381a0b84ae28a1c410c71865b4767c0a265beee54ee8e448a7aa451L43-R44) [[2]](diffhunk://#diff-d7ffbc202381a0b84ae28a1c410c71865b4767c0a265beee54ee8e448a7aa451R96-R102)
* Added a static test variable `_caps` to test client capabilities in `AcquireTokenResultTests`. (`test/Microsoft.Identity.Abstractions.Tests/AcquireTokenResultTests.cs`, [test/Microsoft.Identity.Abstractions.Tests/AcquireTokenResultTests.csR11-R12](diffhunk://#diff-eb0f459f95beeda6796bfc5dc89f3a565a76ab9d3628e75a5284111571074bc6R11-R12))

Fixes #{bug number} (in this specific format)
