### PR TITLE
Fixing AoT warnings: part 1 - non breaking

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
         <!-- This should be passed from the VSTS build -->
-        <MicrosoftIdentityAbstractionsVersion Condition="'$(MicrosoftIdentityAbstractionsVersion)' == ''">9.1.0</MicrosoftIdentityAbstractionsVersion>
+        <MicrosoftIdentityAbstractionsVersion Condition="'$(MicrosoftIdentityAbstractionsVersion)' == ''">9.1.1</MicrosoftIdentityAbstractionsVersion>
         <!-- This will generate AssemblyVersion, AssemblyFileVersion and AssemblyInformationVersion -->
         <Version>$(MicrosoftIdentityAbstractionsVersion)</Version>
         <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)\build\35MSSharedLib1024.snk</AssemblyOriginatorKeyFile>

--- a/src/Microsoft.Identity.Abstractions/DownstreamApi/IDownstreamApi.HttpMethods.cs
+++ b/src/Microsoft.Identity.Abstractions/DownstreamApi/IDownstreamApi.HttpMethods.cs
@@ -6,6 +6,7 @@ using System.Net.Http;
 using System.Security.Claims;
 using System.Threading;
 using System.Threading.Tasks;
+using Microsoft.Identity.Abstractions;
 
 #if NET8_0_OR_GREATER
 using System.Diagnostics.CodeAnalysis;
@@ -49,7 +50,8 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET8_0_OR_GREATER
-        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
+        [RequiresUnreferencedCode("Calls JsonSerializer.Serialize<TInput>")]
+        [RequiresDynamicCode("Calls JsonSerializer.Serialize<TInput>")]
 #endif
         public Task<TOutput?> GetForUserAsync<TOutput>(
             string? serviceName,
@@ -88,7 +90,8 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET8_0_OR_GREATER
-        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
+        [RequiresUnreferencedCode("Calls JsonSerializer.Serialize<TInput>")]
+        [RequiresDynamicCode("Calls JsonSerializer.Serialize<TInput>")]
 #endif
         public Task<TOutput?> GetForUserAsync<TInput, TOutput>(
             string? serviceName,
@@ -122,7 +125,8 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET8_0_OR_GREATER
-        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
+        [RequiresUnreferencedCode("Calls JsonSerializer.Serialize<TInput>")]
+        [RequiresDynamicCode("Calls JsonSerializer.Serialize<TInput>")]
 #endif
         public Task<TOutput?> GetForAppAsync<TOutput>(
             string? serviceName,
@@ -157,7 +161,8 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET8_0_OR_GREATER
-        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
+        [RequiresUnreferencedCode("Calls JsonSerializer.Serialize<TInput>")]
+        [RequiresDynamicCode("Calls JsonSerializer.Serialize<TInput>")]
 #endif
         public Task<TOutput?> GetForAppAsync<TInput, TOutput>(
             string? serviceName,
@@ -195,7 +200,8 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET8_0_OR_GREATER
-        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
+        [RequiresUnreferencedCode("Calls JsonSerializer.Serialize<TInput>")]
+        [RequiresDynamicCode("Calls JsonSerializer.Serialize<TInput>")]
 #endif
         public Task PostForUserAsync<TInput>(
             string? serviceName,
@@ -235,7 +241,8 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET8_0_OR_GREATER
-        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
+        [RequiresUnreferencedCode("Calls JsonSerializer.Serialize<TInput>")]
+        [RequiresDynamicCode("Calls JsonSerializer.Serialize<TInput>")]
 #endif
         public Task<TOutput?> PostForUserAsync<TInput, TOutput>(
             string? serviceName,
@@ -271,7 +278,8 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET8_0_OR_GREATER
-        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
+        [RequiresUnreferencedCode("Calls JsonSerializer.Serialize<TInput>")]
+        [RequiresDynamicCode("Calls JsonSerializer.Serialize<TInput>")]
 #endif
         public Task PostForAppAsync<TInput>(
             string? serviceName,
@@ -307,7 +315,8 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET8_0_OR_GREATER
-        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
+        [RequiresUnreferencedCode("Calls JsonSerializer.Serialize<TInput>")]
+        [RequiresDynamicCode("Calls JsonSerializer.Serialize<TInput>")]
 #endif
         public Task<TOutput?> PostForAppAsync<TInput, TOutput>(
             string? serviceName,
@@ -345,7 +354,8 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET8_0_OR_GREATER
-        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
+        [RequiresUnreferencedCode("Calls JsonSerializer.Serialize<TInput>")]
+        [RequiresDynamicCode("Calls JsonSerializer.Serialize<TInput>")]
 #endif
         public Task PutForUserAsync<TInput>(
             string? serviceName,
@@ -385,7 +395,8 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET8_0_OR_GREATER
-        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
+        [RequiresUnreferencedCode("Calls JsonSerializer.Serialize<TInput>")]
+        [RequiresDynamicCode("Calls JsonSerializer.Serialize<TInput>")]
 #endif
         public Task<TOutput?> PutForUserAsync<TInput, TOutput>(
             string? serviceName,
@@ -421,7 +432,8 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET8_0_OR_GREATER
-        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
+        [RequiresUnreferencedCode("Calls JsonSerializer.Serialize<TInput>")]
+        [RequiresDynamicCode("Calls JsonSerializer.Serialize<TInput>")]
 #endif
         public Task PutForAppAsync<TInput>(
             string? serviceName,
@@ -457,7 +469,8 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET8_0_OR_GREATER
-        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
+        [RequiresUnreferencedCode("Calls JsonSerializer.Serialize<TInput>")]
+        [RequiresDynamicCode("Calls JsonSerializer.Serialize<TInput>")]
 #endif
         public Task<TOutput?> PutForAppAsync<TInput, TOutput>(
             string? serviceName,
@@ -497,7 +510,8 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET8_0_OR_GREATER
-        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
+        [RequiresUnreferencedCode("Calls JsonSerializer.Serialize<TInput>")]
+        [RequiresDynamicCode("Calls JsonSerializer.Serialize<TInput>")]
 #endif
         public Task PatchForUserAsync<TInput>(
             string? serviceName,
@@ -537,7 +551,8 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET8_0_OR_GREATER
-        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
+        [RequiresUnreferencedCode("Calls JsonSerializer.Serialize<TInput>")]
+        [RequiresDynamicCode("Calls JsonSerializer.Serialize<TInput>")]
 #endif
         public Task<TOutput?> PatchForUserAsync<TInput, TOutput>(
             string? serviceName,
@@ -573,7 +588,8 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET8_0_OR_GREATER
-        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
+        [RequiresUnreferencedCode("Calls JsonSerializer.Serialize<TInput>")]
+        [RequiresDynamicCode("Calls JsonSerializer.Serialize<TInput>")]
 #endif
         public Task PatchForAppAsync<TInput>(
             string? serviceName,
@@ -609,7 +625,8 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET8_0_OR_GREATER
-        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
+        [RequiresUnreferencedCode("Calls JsonSerializer.Serialize<TInput>")]
+        [RequiresDynamicCode("Calls JsonSerializer.Serialize<TInput>")]
 #endif
         public Task<TOutput?> PatchForAppAsync<TInput, TOutput>(
             string? serviceName,
@@ -649,7 +666,8 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET8_0_OR_GREATER
-        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
+        [RequiresUnreferencedCode("Calls JsonSerializer.Serialize<TInput>")]
+        [RequiresDynamicCode("Calls JsonSerializer.Serialize<TInput>")]
 #endif
         public Task DeleteForUserAsync<TInput>(
             string? serviceName,
@@ -689,7 +707,8 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET8_0_OR_GREATER
-        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
+        [RequiresUnreferencedCode("Calls JsonSerializer.Serialize<TInput>")]
+        [RequiresDynamicCode("Calls JsonSerializer.Serialize<TInput>")]
 #endif
         public Task<TOutput?> DeleteForUserAsync<TInput, TOutput>(
             string? serviceName,
@@ -725,7 +744,8 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET8_0_OR_GREATER
-        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
+        [RequiresUnreferencedCode("Calls JsonSerializer.Serialize<TInput>")]
+        [RequiresDynamicCode("Calls JsonSerializer.Serialize<TInput>")]
 #endif
         public Task DeleteForAppAsync<TInput>(
             string? serviceName,
@@ -761,7 +781,8 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET8_0_OR_GREATER
-        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
+        [RequiresUnreferencedCode("Calls JsonSerializer.Serialize<TInput>")]
+        [RequiresDynamicCode("Calls JsonSerializer.Serialize<TInput>")]
 #endif
         public Task<TOutput?> DeleteForAppAsync<TInput, TOutput>(
             string? serviceName,

--- a/src/Microsoft.Identity.Abstractions/DownstreamApi/IDownstreamApi.HttpMethods.tt
+++ b/src/Microsoft.Identity.Abstractions/DownstreamApi/IDownstreamApi.HttpMethods.tt
@@ -114,9 +114,10 @@ namespace Microsoft.Identity.Abstractions
         ///         });
         /// </code>
         /// </example>
-<# if (framework != "net8"){ #>
+<# if ((hasInput || hasOutput) && (framework != "net8" && framework != "net9")){ #>
 #if NET8_0_OR_GREATER
-        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
+        [RequiresUnreferencedCode("Calls JsonSerializer.Serialize<TInput>")]
+        [RequiresDynamicCode("Calls JsonSerializer.Serialize<TInput>")]
 #endif
 <# } #>
         public <#= returnType #> <#= httpMethod #>For<#= token #>Async<#= template #>(
@@ -124,10 +125,10 @@ namespace Microsoft.Identity.Abstractions
 <# if (hasInput){ #>
             TInput input,
 <# } #>
-<# if (hasInput && framework == "net8"){ #>
+<# if (hasInput && (framework == "net8" || framework == "net9")){ #>
             JsonTypeInfo<TInput> inputJsonTypeInfo,
 <# } #>
-<# if (hasOutput && framework == "net8"){ #>
+<# if (hasOutput && (framework == "net8" || framework == "net9")){ #>
             JsonTypeInfo<TOutput> outputJsonTypeInfo,
 <# } #>
             Action<DownstreamApiOptionsReadOnlyHttpMethod>? downstreamApiOptionsOverride = null,

--- a/src/Microsoft.Identity.Abstractions/DownstreamApi/IDownstreamApi.cs
+++ b/src/Microsoft.Identity.Abstractions/DownstreamApi/IDownstreamApi.cs
@@ -161,7 +161,8 @@ namespace Microsoft.Identity.Abstractions
         /// </code>
         /// </example>
 #if NET8_0_OR_GREATER
-        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
+        [RequiresUnreferencedCode("Calls JsonSerializer.Serialize<TInput>")]
+        [RequiresDynamicCode("Calls JsonSerializer.Serialize<TInput>")]
 #endif
         Task<TOutput?> CallApiForUserAsync<TInput, TOutput>(
             string? serviceName,
@@ -187,7 +188,8 @@ namespace Microsoft.Identity.Abstractions
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The value returned by the downstream web API.</returns>
 #if NET8_0_OR_GREATER
-        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
+        [RequiresUnreferencedCode("Calls JsonSerializer.Serialize<TInput>")]
+        [RequiresDynamicCode("Calls JsonSerializer.Serialize<TInput>")]
 #endif
         Task<TOutput?> CallApiForUserAsync<TOutput>(
             string serviceName,
@@ -211,7 +213,8 @@ namespace Microsoft.Identity.Abstractions
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The value returned by the downstream web API.</returns>
 #if NET8_0_OR_GREATER
-        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
+        [RequiresUnreferencedCode("Calls JsonSerializer.Serialize<TInput>")]
+        [RequiresDynamicCode("Calls JsonSerializer.Serialize<TInput>")]
 #endif
         Task<TOutput?> CallApiForAppAsync<TInput, TOutput>(
             string? serviceName,
@@ -233,7 +236,8 @@ namespace Microsoft.Identity.Abstractions
         /// <param name="cancellationToken">Cancellation token.</param>
         /// <returns>The value returned by the downstream web API.</returns>
 #if NET8_0_OR_GREATER
-        [RequiresUnreferencedCode("This method's implementations also use generic types and are not trim-friendly.")]
+        [RequiresUnreferencedCode("Calls JsonSerializer.Serialize<TInput>")]
+        [RequiresDynamicCode("Calls JsonSerializer.Serialize<TInput>")]
 #endif
         Task<TOutput?> CallApiForAppAsync<TOutput>(
             string serviceName,


### PR DESCRIPTION
# Fixing AoT warnings: part 1 - non breaking
Contrary to https://github.com/AzureAD/microsoft-identity-abstractions-for-dotnet/pull/178 which introduces breaking changes in the CredentialDescription, this PR does not introduce breaking changes. It's needed to fix AoT warnings in Microsoft.Identity.Web.DownstrreamApi
