### PR TITLE
Plumb ClientCapabilities through CredentialSourceLoaderParameters and TokenAcquisition to Managed-Identity client-assertion flows

### DIFF
--- a/src/Microsoft.Identity.Abstractions/ApplicationOptions/CredentialSourceLoaderParameters.cs
+++ b/src/Microsoft.Identity.Abstractions/ApplicationOptions/CredentialSourceLoaderParameters.cs
@@ -1,6 +1,9 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
+using System.Linq;
+
 namespace Microsoft.Identity.Abstractions
 {
     /// <summary>
@@ -21,6 +24,27 @@ namespace Microsoft.Identity.Abstractions
         {
             ClientId = clientId;
             Authority = authority;
+            ClientCapabilities = [];
+        }
+
+        /// <summary>
+        /// Initialize the CredentialSourceLoaderParameters from the application ID and authority.
+        /// </summary>
+        /// <param name="clientId">Application ID of the confidential client application that
+        /// wants to use these credentials as client credentials</param>
+        /// <param name="authority">Authority (Cloud instance and tenant) to which the credential will be presented.</param>
+        /// <param name="clientCapabilities">Client capabilities that the application supports.</param>
+        public CredentialSourceLoaderParameters(
+            string clientId,
+            string authority,
+            IEnumerable<string> clientCapabilities)
+        {
+            ClientId = clientId;
+            Authority = authority;
+
+            ClientCapabilities = (clientCapabilities?.Any() == true)
+                ? clientCapabilities.ToArray()
+                : [];
         }
 
         /// <summary>
@@ -32,5 +56,10 @@ namespace Microsoft.Identity.Abstractions
         /// Authority (Cloud instance and tenant) to which the credential will be presented.
         /// </summary>
         public string Authority { get; set; }
+
+        /// <summary>
+        /// Client capabilities that the application supports. 
+        /// </summary>
+        public IReadOnlyCollection<string> ClientCapabilities { get; }
     }
 }

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/net462/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/net462/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.Identity.Abstractions.CredentialSourceLoaderParameters.ClientCapabilities.get -> System.Collections.Generic.IReadOnlyCollection<string!>!
+Microsoft.Identity.Abstractions.CredentialSourceLoaderParameters.CredentialSourceLoaderParameters(string! clientId, string! authority, System.Collections.Generic.IEnumerable<string!>! clientCapabilities) -> void

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.Identity.Abstractions.CredentialSourceLoaderParameters.ClientCapabilities.get -> System.Collections.Generic.IReadOnlyCollection<string!>!
+Microsoft.Identity.Abstractions.CredentialSourceLoaderParameters.CredentialSourceLoaderParameters(string! clientId, string! authority, System.Collections.Generic.IEnumerable<string!>! clientCapabilities) -> void

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/net9.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/net9.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.Identity.Abstractions.CredentialSourceLoaderParameters.ClientCapabilities.get -> System.Collections.Generic.IReadOnlyCollection<string!>!
+Microsoft.Identity.Abstractions.CredentialSourceLoaderParameters.CredentialSourceLoaderParameters(string! clientId, string! authority, System.Collections.Generic.IEnumerable<string!>! clientCapabilities) -> void

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.Identity.Abstractions.CredentialSourceLoaderParameters.ClientCapabilities.get -> System.Collections.Generic.IReadOnlyCollection<string!>!
+Microsoft.Identity.Abstractions.CredentialSourceLoaderParameters.CredentialSourceLoaderParameters(string! clientId, string! authority, System.Collections.Generic.IEnumerable<string!>! clientCapabilities) -> void

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.Identity.Abstractions.CredentialSourceLoaderParameters.ClientCapabilities.get -> System.Collections.Generic.IReadOnlyCollection<string!>!
+Microsoft.Identity.Abstractions.CredentialSourceLoaderParameters.CredentialSourceLoaderParameters(string! clientId, string! authority, System.Collections.Generic.IEnumerable<string!>! clientCapabilities) -> void

--- a/test/Microsoft.Identity.Abstractions.Tests/CredentialSourceLoaderParametersTest.cs
+++ b/test/Microsoft.Identity.Abstractions.Tests/CredentialSourceLoaderParametersTest.cs
@@ -7,16 +7,33 @@ namespace Microsoft.Identity.Abstractions.ApplicationOptions.Tests
 {
     public class CredentialSourceLoaderParametersTest
     {
-        const string clientId = "ClientId-from-app-registration";
-        const string authority = "https://login.microsoftonline.com/common/v2.0";
+        const string ClientId = "ClientId-from-app-registration";
+        const string Authority = "https://login.microsoftonline.com/common/v2.0";
         
         [Fact]
         public void CredentialSourceLoaderParametersProperties()
         {
-            CredentialSourceLoaderParameters parameters = new(clientId, authority);
+            CredentialSourceLoaderParameters parameters = new(ClientId, Authority);
 
-            Assert.Equal(clientId, parameters.ClientId);
-            Assert.Equal(authority, parameters.Authority);
+            Assert.Equal(ClientId, parameters.ClientId);
+            Assert.Equal(Authority, parameters.Authority);
+            Assert.NotNull(parameters.ClientCapabilities);
+            Assert.Empty(parameters.ClientCapabilities);
+        }
+
+        [Fact]
+        public void CredentialSourceLoaderParametersProperties_WithCapabilities()
+        {
+            // Arrange
+            var caps = new[] { "cp1", "llt" };
+
+            // Act
+            CredentialSourceLoaderParameters parameters = new(ClientId, Authority, caps);
+
+            // Assert
+            Assert.Equal(ClientId, parameters.ClientId);
+            Assert.Equal(Authority, parameters.Authority);
+            Assert.Equal(caps, parameters.ClientCapabilities);
         }
     }
 }


### PR DESCRIPTION
# Plumb ClientCapabilities through CredentialSourceLoaderParameters and TokenAcquisition to Managed-Identity client-assertion flows

- [x] You've read the [Contributor Guide](https://github.com/AzureAD/microsoft-identity-web/blob/master/CONTRIBUTING.md) and [Code of Conduct](https://github.com/AzureAD/microsoft-identity-web/blob/master/CODE_OF_CONDUCT.md).
- [x] You've included unit or integration tests for your change, where applicable.
- [x] You've included inline docs for your change, where applicable.
- [x] There's an open issue for the PR that you are making. If you'd like to propose a new feature or change, please open an issue to discuss the change or find an existing issue.

Summary of the changes (Less than 80 chars)

## Description

- adds a new ClientCapabilities field on CredentialSourceLoaderParameters,

- will be used to update [TokenAcquisition](https://github.com/AzureAD/microsoft-identity-web/blob/master/src/Microsoft.Identity.Web.TokenAcquisition/TokenAcquisition.cs#L923) (WithClientCredentialsAsync) where the list is passed, and

- the ultimate consumer—the Managed-Identity client-assertion path to support token revocation features. 

Fixes #{bug number} (in this specific format)
