### PR TITLE
Add enum for managed certificate

### DIFF
--- a/src/Microsoft.Identity.Abstractions/ApplicationOptions/CredentialSource.cs
+++ b/src/Microsoft.Identity.Abstractions/ApplicationOptions/CredentialSource.cs
@@ -184,6 +184,11 @@ namespace Microsoft.Identity.Abstractions
         /// Use this value in order to utilize a credential provider that is not part of the Microsoft.Identity.Abstractions library.
         /// This is an extension point, which goes along with <see cref = "CredentialDescription.CustomSignedAssertionProviderName" />
         /// </summary>
-        CustomSignedAssertion = 11
+        CustomSignedAssertion = 11,
+
+        /// <summary>
+        /// Use this value to indicate that the credential is a managed certificate, which is a certificate that is automatically
+        /// </summary>
+        ManagedCertificate = 12,
     }
 }

--- a/src/Microsoft.Identity.Abstractions/ApplicationOptions/CredentialSource.cs
+++ b/src/Microsoft.Identity.Abstractions/ApplicationOptions/CredentialSource.cs
@@ -187,7 +187,8 @@ namespace Microsoft.Identity.Abstractions
         CustomSignedAssertion = 11,
 
         /// <summary>
-        /// Use this value to indicate that the credential is a managed certificate, which is a certificate that is automatically
+        /// Use this value to indicate that the credential is a managed certificate.
+        /// This is currently a Microsoft-Internal concept which has no meaning outside of Microsoft.
         /// </summary>
         ManagedCertificate = 12,
     }

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -1,3 +1,4 @@
 #nullable enable
+Microsoft.Identity.Abstractions.CredentialSource.ManagedCertificate = 12 -> Microsoft.Identity.Abstractions.CredentialSource
 Microsoft.Identity.Abstractions.IAuthenticationSchemeInformationProvider
 Microsoft.Identity.Abstractions.IAuthenticationSchemeInformationProvider.GetEffectiveAuthenticationScheme(string? authenticationScheme) -> string!

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/net462/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/net462/PublicAPI.Unshipped.txt
@@ -3,5 +3,6 @@ Microsoft.Identity.Abstractions.AcquireTokenResult.AdditionalResponseParameters.
 Microsoft.Identity.Abstractions.AcquireTokenResult.AdditionalResponseParameters.set -> void
 Microsoft.Identity.Abstractions.AcquireTokenResult.BindingCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2?
 Microsoft.Identity.Abstractions.AcquireTokenResult.BindingCertificate.set -> void
+Microsoft.Identity.Abstractions.CredentialSource.ManagedCertificate = 12 -> Microsoft.Identity.Abstractions.CredentialSource
 Microsoft.Identity.Abstractions.IAuthenticationSchemeInformationProvider
 Microsoft.Identity.Abstractions.IAuthenticationSchemeInformationProvider.GetEffectiveAuthenticationScheme(string? authenticationScheme) -> string!

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -3,5 +3,6 @@ Microsoft.Identity.Abstractions.AcquireTokenResult.AdditionalResponseParameters.
 Microsoft.Identity.Abstractions.AcquireTokenResult.AdditionalResponseParameters.set -> void
 Microsoft.Identity.Abstractions.AcquireTokenResult.BindingCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2?
 Microsoft.Identity.Abstractions.AcquireTokenResult.BindingCertificate.set -> void
+Microsoft.Identity.Abstractions.CredentialSource.ManagedCertificate = 12 -> Microsoft.Identity.Abstractions.CredentialSource
 Microsoft.Identity.Abstractions.IAuthenticationSchemeInformationProvider
 Microsoft.Identity.Abstractions.IAuthenticationSchemeInformationProvider.GetEffectiveAuthenticationScheme(string? authenticationScheme) -> string!

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/net9.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/net9.0/PublicAPI.Unshipped.txt
@@ -3,5 +3,6 @@ Microsoft.Identity.Abstractions.AcquireTokenResult.AdditionalResponseParameters.
 Microsoft.Identity.Abstractions.AcquireTokenResult.AdditionalResponseParameters.set -> void
 Microsoft.Identity.Abstractions.AcquireTokenResult.BindingCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2?
 Microsoft.Identity.Abstractions.AcquireTokenResult.BindingCertificate.set -> void
+Microsoft.Identity.Abstractions.CredentialSource.ManagedCertificate = 12 -> Microsoft.Identity.Abstractions.CredentialSource
 Microsoft.Identity.Abstractions.IAuthenticationSchemeInformationProvider
 Microsoft.Identity.Abstractions.IAuthenticationSchemeInformationProvider.GetEffectiveAuthenticationScheme(string? authenticationScheme) -> string!

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -3,5 +3,6 @@ Microsoft.Identity.Abstractions.AcquireTokenResult.AdditionalResponseParameters.
 Microsoft.Identity.Abstractions.AcquireTokenResult.AdditionalResponseParameters.set -> void
 Microsoft.Identity.Abstractions.AcquireTokenResult.BindingCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2?
 Microsoft.Identity.Abstractions.AcquireTokenResult.BindingCertificate.set -> void
+Microsoft.Identity.Abstractions.CredentialSource.ManagedCertificate = 12 -> Microsoft.Identity.Abstractions.CredentialSource
 Microsoft.Identity.Abstractions.IAuthenticationSchemeInformationProvider
 Microsoft.Identity.Abstractions.IAuthenticationSchemeInformationProvider.GetEffectiveAuthenticationScheme(string? authenticationScheme) -> string!

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
@@ -3,5 +3,6 @@ Microsoft.Identity.Abstractions.AcquireTokenResult.AdditionalResponseParameters.
 Microsoft.Identity.Abstractions.AcquireTokenResult.AdditionalResponseParameters.set -> void
 Microsoft.Identity.Abstractions.AcquireTokenResult.BindingCertificate.get -> System.Security.Cryptography.X509Certificates.X509Certificate2?
 Microsoft.Identity.Abstractions.AcquireTokenResult.BindingCertificate.set -> void
+Microsoft.Identity.Abstractions.CredentialSource.ManagedCertificate = 12 -> Microsoft.Identity.Abstractions.CredentialSource
 Microsoft.Identity.Abstractions.IAuthenticationSchemeInformationProvider
 Microsoft.Identity.Abstractions.IAuthenticationSchemeInformationProvider.GetEffectiveAuthenticationScheme(string? authenticationScheme) -> string!

--- a/test/Microsoft.Identity.Abstractions.Tests/CredentialDescriptionTest.cs
+++ b/test/Microsoft.Identity.Abstractions.Tests/CredentialDescriptionTest.cs
@@ -505,5 +505,23 @@ namespace Microsoft.Identity.Abstractions.ApplicationOptions.Tests
             // Assert
             Assert.Equal(original.Algorithm, copy.Algorithm);
         }
+
+        [Fact]
+        public void ManagedCertificateCredential()
+        {
+            // Example value of what the managed certificate string will likely look like.
+            string exampleManagedCertId = "Keyvault::myvault.vault.core.windows.net/secrets/mycert::11111-2222-3333-4444";
+            CredentialDescription credentialDescription = new CredentialDescription
+            {
+                SourceType = CredentialSource.ManagedCertificate,
+                CachedValue = exampleManagedCertId
+            };
+            // </managedcertificate_csharp>
+
+            Assert.Equal(CredentialType.Certificate, credentialDescription.CredentialType);
+            Assert.Equal("ManagedCertificate={exampleManagedCertId}", credentialDescription.Id);
+            credentialDescription.CachedValue = null;
+            Assert.Equal("ManagedCertificate=null", credentialDescription.Id);
+        }
     }
 }


### PR DESCRIPTION
# Add enum for managed certificate

Adds in a new enum value for managed certificate. This is currently a microsoft-internal concept which will have no functionality outside of microsoft. In the future, support will be extended to third-party customers.

This PR incldues a fix for CredentialDescription.ID where the value would be cached on first call and never refreshed. This means that certain credentials which can change (most notable Certificate and this new one) the data will get stale as rollovers occur. This fix will invalidate the cache when Certificate or CachedValue update, which will correctly update the ID.

