### PR TITLE
Add CredentialDescription.UseBoundCredential for Bearer-over-mTLS opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ direction TB
             &lt;&lt;rw&gt;&gt; +X509Certificate2 Certificate
             &lt;&lt;rw&gt;&gt; +object CachedValue
             &lt;&lt;rw&gt;&gt; +bool Skip
+            &lt;&lt;rw&gt;&gt; +bool UseBoundCredential
             &lt;&lt;ro&gt;&gt; +CredentialType CredentialType
             &lt;&lt;rw&gt;&gt; +string TokenExchangeUrl
             &lt;&lt;rw&gt;&gt; +string CustomSignedAssertionProviderName
@@ -315,6 +316,7 @@ Note:
     &lt;&lt;rw&gt;&gt; +X509Certificate2 Certificate
     &lt;&lt;rw&gt;&gt; +Object CachedValue
     &lt;&lt;rw&gt;&gt; +bool Skip
+    &lt;&lt;rw&gt;&gt; +bool UseBoundCredential
     &lt;&lt;ro&gt;&gt; +CredentialType CredentialType
     &lt;&lt;rw&gt;&gt; +string TokenExchangeUrl
     &lt;&lt;rw&gt;&gt; +string CustomSignedAssertionProviderName

--- a/src/Microsoft.Identity.Abstractions/ApplicationOptions/CredentialDescription.cs
+++ b/src/Microsoft.Identity.Abstractions/ApplicationOptions/CredentialDescription.cs
@@ -37,7 +37,7 @@ namespace Microsoft.Identity.Abstractions
 #if NET8_0_OR_GREATER
             ArgumentNullException.ThrowIfNull(other);
 #else
-            if (other == null)
+            if (other is null)
                 throw new ArgumentNullException(nameof(other));
 #endif
             Algorithm = other.Algorithm;
@@ -63,6 +63,7 @@ namespace Microsoft.Identity.Abstractions
             SourceType = other.SourceType;
             TokenExchangeUrl = other.TokenExchangeUrl;
             TokenExchangeAuthority = other.TokenExchangeAuthority;
+            UseBoundCredential = other.UseBoundCredential;
         }
 
         private string? _cachedId;
@@ -571,6 +572,43 @@ namespace Microsoft.Identity.Abstractions
         /// It will also be used by the <see cref="ICredentialsLoader"/> if it cannot find or load the credential.
         /// </summary>
         public bool Skip { get; set; }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether this credential is intended to be used as a bound credential (mTLS bound)
+        /// when supported by the host library.
+        /// Certificate-flavored sources (<see cref="CredentialSource.Certificate"/>, <see cref="CredentialSource.KeyVault"/>,
+        /// <see cref="CredentialSource.Base64Encoded"/>, <see cref="CredentialSource.Path"/>,
+        /// <see cref="CredentialSource.StoreWithThumbprint"/>, <see cref="CredentialSource.StoreWithDistinguishedName"/>,
+        /// <see cref="CredentialSource.StoreWithSubjectName"/>, and <see cref="CredentialSource.ManagedCertificate"/>)
+        /// and <see cref="CredentialSource.SignedAssertionFromManagedIdentity"/> are expected to honor this setting.
+        /// Other source types are expected to ignore this setting, based on the host library's choice.
+        /// The default value is <see langword="false"/>, which preserves existing behavior.
+        /// For more context, see <see href="https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/5791">MSAL.NET issue 5791</see>.
+        /// </summary>
+        /// <example>
+        /// <format type="text/markdown">
+        /// <![CDATA[
+        /// The JSON fragment below opts a signed assertion from managed identity credential into the bound credential flow:
+        /// ```json
+        /// {
+        ///   "AzureAd": {
+        ///     "Instance": "https://login.microsoftonline.com/",
+        ///     "TenantId": "your-tenant-id",
+        ///     "ClientId": "your-client-id",
+        ///     "ClientCredentials": [
+        ///       {
+        ///         "SourceType": "SignedAssertionFromManagedIdentity",
+        ///         "ManagedIdentityClientId": "your-user-assigned-managed-identity-client-id",
+        ///         "TokenExchangeUrl": "api://AzureADTokenExchange",
+        ///         "UseBoundCredential": true
+        ///       }
+        ///     ]
+        ///   }
+        /// }
+        /// ```
+        /// ]]></format>
+        /// </example>
+        public bool UseBoundCredential { get; set; }
 
         /// <summary>
         /// Describes the type of credentials, based on the <see cref="SourceType"/>.

--- a/src/Microsoft.Identity.Abstractions/ApplicationOptions/CredentialDescriptionJsonConverter.cs
+++ b/src/Microsoft.Identity.Abstractions/ApplicationOptions/CredentialDescriptionJsonConverter.cs
@@ -92,6 +92,9 @@ namespace Microsoft.Identity.Abstractions
                     case string _ when propertyName.Equals(nameof(CredentialDescription.Skip), StringComparison.OrdinalIgnoreCase):
                         credentialDescription.Skip = reader.GetBoolean();
                         break;
+                    case string _ when propertyName.Equals(nameof(CredentialDescription.UseBoundCredential), StringComparison.OrdinalIgnoreCase):
+                        credentialDescription.UseBoundCredential = reader.GetBoolean();
+                        break;
                     case string _ when propertyName.Equals(nameof(CredentialDescription.CustomSignedAssertionProviderName), StringComparison.OrdinalIgnoreCase):
                         credentialDescription.CustomSignedAssertionProviderName = reader.GetString();
                         break;
@@ -197,6 +200,11 @@ namespace Microsoft.Identity.Abstractions
                         JsonSerializer.Serialize(writer, value.CustomSignedAssertionProviderData, options);
                     }
                     break;
+            }
+
+            if (value.UseBoundCredential)
+            {
+                writer.WriteBoolean(nameof(CredentialDescription.UseBoundCredential), value.UseBoundCredential);
             }
 
             writer.WriteEndObject();

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 #nullable enable
+Microsoft.Identity.Abstractions.CredentialDescription.UseBoundCredential.get -> bool
+Microsoft.Identity.Abstractions.CredentialDescription.UseBoundCredential.set -> void
 Microsoft.Identity.Abstractions.CredentialSourceLoaderParameters.ApiUrl.get -> string?
 Microsoft.Identity.Abstractions.CredentialSourceLoaderParameters.ApiUrl.set -> void
 Microsoft.Identity.Abstractions.CredentialSourceLoaderParameters.Protocol.get -> string?

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/net462/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/net462/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 #nullable enable
+Microsoft.Identity.Abstractions.CredentialDescription.UseBoundCredential.get -> bool
+Microsoft.Identity.Abstractions.CredentialDescription.UseBoundCredential.set -> void
 Microsoft.Identity.Abstractions.CredentialSourceLoaderParameters.ApiUrl.get -> string?
 Microsoft.Identity.Abstractions.CredentialSourceLoaderParameters.ApiUrl.set -> void
 Microsoft.Identity.Abstractions.CredentialSourceLoaderParameters.Protocol.get -> string?

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 #nullable enable
+Microsoft.Identity.Abstractions.CredentialDescription.UseBoundCredential.get -> bool
+Microsoft.Identity.Abstractions.CredentialDescription.UseBoundCredential.set -> void
 Microsoft.Identity.Abstractions.CredentialSourceLoaderParameters.ApiUrl.get -> string?
 Microsoft.Identity.Abstractions.CredentialSourceLoaderParameters.ApiUrl.set -> void
 Microsoft.Identity.Abstractions.CredentialSourceLoaderParameters.Protocol.get -> string?

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/net9.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/net9.0/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 #nullable enable
+Microsoft.Identity.Abstractions.CredentialDescription.UseBoundCredential.get -> bool
+Microsoft.Identity.Abstractions.CredentialDescription.UseBoundCredential.set -> void
 Microsoft.Identity.Abstractions.CredentialSourceLoaderParameters.ApiUrl.get -> string?
 Microsoft.Identity.Abstractions.CredentialSourceLoaderParameters.ApiUrl.set -> void
 Microsoft.Identity.Abstractions.CredentialSourceLoaderParameters.Protocol.get -> string?

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 #nullable enable
+Microsoft.Identity.Abstractions.CredentialDescription.UseBoundCredential.get -> bool
+Microsoft.Identity.Abstractions.CredentialDescription.UseBoundCredential.set -> void
 Microsoft.Identity.Abstractions.CredentialSourceLoaderParameters.ApiUrl.get -> string?
 Microsoft.Identity.Abstractions.CredentialSourceLoaderParameters.ApiUrl.set -> void
 Microsoft.Identity.Abstractions.CredentialSourceLoaderParameters.Protocol.get -> string?

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
@@ -1,4 +1,6 @@
 #nullable enable
+Microsoft.Identity.Abstractions.CredentialDescription.UseBoundCredential.get -> bool
+Microsoft.Identity.Abstractions.CredentialDescription.UseBoundCredential.set -> void
 Microsoft.Identity.Abstractions.CredentialSourceLoaderParameters.ApiUrl.get -> string?
 Microsoft.Identity.Abstractions.CredentialSourceLoaderParameters.ApiUrl.set -> void
 Microsoft.Identity.Abstractions.CredentialSourceLoaderParameters.Protocol.get -> string?

--- a/test/Microsoft.Identity.Abstractions.Tests/CredentialDescriptionTest.cs
+++ b/test/Microsoft.Identity.Abstractions.Tests/CredentialDescriptionTest.cs
@@ -1,9 +1,12 @@
 ﻿// Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
-using Xunit;
-using System.Collections.Generic;
 using System;
+using System.Collections.Generic;
+#if NET8_0_OR_GREATER
+using System.Text.Json;
+#endif
+using Xunit;
 
 namespace Microsoft.Identity.Abstractions.ApplicationOptions.Tests
 {
@@ -400,6 +403,95 @@ namespace Microsoft.Identity.Abstractions.ApplicationOptions.Tests
 
             Assert.Equal("api://AzureADTokenExchangeChina", credentialDescription.TokenExchangeUrl);
         }
+
+        [Fact]
+        public void CredentialDescription_DefaultUseBoundCredential_IsFalse()
+        {
+            // Arrange
+            var credentialDescription = new CredentialDescription();
+
+            // Act
+            bool useBoundCredential = credentialDescription.UseBoundCredential;
+
+            // Assert
+            Assert.False(useBoundCredential);
+        }
+
+        [Fact]
+        public void CredentialDescription_UseBoundCredential_SetTrue_RoundTrips()
+        {
+            // Arrange
+            var credentialDescription = new CredentialDescription();
+
+            // Act
+            credentialDescription.UseBoundCredential = true;
+
+            // Assert
+            Assert.True(credentialDescription.UseBoundCredential);
+        }
+
+        [Fact]
+        public void CopyConstructor_ShouldCopyUseBoundCredentialTrue()
+        {
+            // Arrange
+            var original = new CredentialDescription
+            {
+                UseBoundCredential = true
+            };
+
+            // Act
+            var copy = new CredentialDescription(original);
+
+            // Assert
+            Assert.True(copy.UseBoundCredential);
+        }
+
+        [Fact]
+        public void CopyConstructor_ShouldCopyUseBoundCredentialFalse()
+        {
+            // Arrange
+            var original = new CredentialDescription
+            {
+                UseBoundCredential = false
+            };
+
+            // Act
+            var copy = new CredentialDescription(original);
+
+            // Assert
+            Assert.False(copy.UseBoundCredential);
+        }
+
+#if NET8_0_OR_GREATER
+        [Fact]
+        public void CredentialDescription_UseBoundCredentialJson_RoundTripsWithConverter()
+        {
+            // Arrange
+            var options = new JsonSerializerOptions
+            {
+                Converters = { new CredentialDescriptionJsonConverter() }
+            };
+            string json = """
+                {
+                  "SourceType": "SignedAssertionFromManagedIdentity",
+                  "ManagedIdentityClientId": "your-user-assigned-managed-identity-client-id",
+                  "TokenExchangeUrl": "api://AzureADTokenExchange",
+                  "UseBoundCredential": true
+                }
+                """;
+
+            // Act
+            var credentialDescription = JsonSerializer.Deserialize<CredentialDescription>(json, options);
+            string roundTripJson = JsonSerializer.Serialize(credentialDescription!, options);
+            var roundTrippedCredentialDescription = JsonSerializer.Deserialize<CredentialDescription>(roundTripJson, options);
+
+            // Assert
+            Assert.NotNull(credentialDescription);
+            Assert.True(credentialDescription!.UseBoundCredential);
+            Assert.NotNull(roundTrippedCredentialDescription);
+            Assert.True(roundTrippedCredentialDescription!.UseBoundCredential);
+        }
+#endif
 
         [Fact]
         public void UnknownCredentialSource()


### PR DESCRIPTION
## Summary
Adds a new `UseBoundCredential` (bool, default `false`) property on `CredentialDescription`. When set, the credential is treated as opted-in to the bound-credential (Bearer-over-mTLS) flow. The setting is per-credential: each `CredentialDescription` in `ClientCredentials[]` decides for itself, so an app can mix bound and non-bound credentials freely.

Consumers (MSAL.NET / Microsoft.Identity.Web) read this property to decide whether to:
- Present a certificate over mTLS (`CertificateOptions.SendCertificateOverMtls = true`) for `Certificate`-type credentials, or
- Wire a bound-credential bundle (signed assertion + binding certificate) via `WithClientAssertion(Func<…, ClientSignedAssertion>)` for `SignedAssertionFromManagedIdentity`-type credentials.

Companion to MSAL.NET issue: https://github.com/AzureAD/microsoft-authentication-library-for-dotnet/issues/5791

## Configuration shape
```json
{
  "ClientCredentials": [
    {
      "SourceType": "SignedAssertionFromManagedIdentity",
      "ManagedIdentityClientId": "your-user-assigned-managed-identity-client-id",
      "TokenExchangeUrl": "api://AzureADTokenExchange",
      "UseBoundCredential": true
    }
  ]
}
```

## Changes
- `CredentialDescription.UseBoundCredential` property + copy constructor propagation.
- `CredentialDescriptionJsonConverter` updated to round-trip the new property through System.Text.Json.
- `README.md` mermaid diagram updated.
- Public API tracker updated for all 6 TFMs (net462 / netstandard2.0 / netstandard2.1 / net8.0 / net9.0 / net10.0).
- Tests: default value, copy-constructor propagation, JSON round-trip via the converter.

## Validation
- Full unit test suite: **291 / 291 pass** (net8.0 + net10.0 + net462).
- Public API analyzer clean across all TFMs.

## Notes for reviewers
- The new property is purely declarative on the abstractions surface — no behavior change in this repo. The consumer libraries (MSAL.NET, Microsoft.Identity.Web) interpret it at credential-load time.
- Default is `false`, so existing configurations are unaffected.