### PR TITLE
Update changelog for 12.3.0 (PR #257)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+12.3.0
+=======
+
+## What's Changed
+* Added `IAuthorizationHeaderProvider2` (extends `IAuthorizationHeaderProvider`) with metadata-returning counterparts to the three base header-creation methods: `CreateAuthorizationHeaderInformationForUserAsync`, `CreateAuthorizationHeaderInformationForAppAsync`, and `CreateAuthorizationHeaderInformationAsync`. Each mirrors the inputs of its base method and returns `OperationResult<AuthorizationHeaderInformation, AuthorizationHeaderError>` (header value, binding certificate, and token-acquisition metadata) instead of a bare `string`. Additive and non-breaking — existing string-returning callers are unaffected. See [#257](https://github.com/AzureAD/microsoft-identity-abstractions-for-dotnet/pull/257).
+
 12.2.0
 =======
 


### PR DESCRIPTION

This pull request updates the `changelog.md` file to document the release of version 12.3.0. The main change is the addition of a new interface, `IAuthorizationHeaderProvider2`, which extends the existing authorization header provider interface with enhanced, metadata-rich methods. This change is additive and non-breaking, ensuring backward compatibility.

Changelog update:

* Added release notes for version 12.3.0, highlighting the introduction of `IAuthorizationHeaderProvider2` with metadata-returning methods that complement the original string-returning methods for creating authorization headers.
