### PR TITLE
Add ServiceErrorCodes to TokenAcquisitionFailureDetails

### DIFF
--- a/src/Microsoft.Identity.Abstractions/DownstreamApi/TokenAcquisitionFailureDetails.cs
+++ b/src/Microsoft.Identity.Abstractions/DownstreamApi/TokenAcquisitionFailureDetails.cs
@@ -32,7 +32,7 @@ namespace Microsoft.Identity.Abstractions
         /// <summary>
         /// The raw STS-specific error codes returned by the token service (for example the numeric
         /// <c>AADSTS</c> codes) that further refine <see cref="ErrorCode"/>. Mirrors
-        /// <c>MsalServiceException.ErrorCodes</c> when MSAL is the underlying acquirer; diagnostic only.
+        /// <c>MsalServiceException.ErrorCodesForLogging</c> when MSAL is the underlying acquirer; diagnostic only.
         /// </summary>
         public IReadOnlyList<string>? ServiceErrorCodes { get; init; }
 

--- a/src/Microsoft.Identity.Abstractions/DownstreamApi/TokenAcquisitionFailureDetails.cs
+++ b/src/Microsoft.Identity.Abstractions/DownstreamApi/TokenAcquisitionFailureDetails.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // Licensed under the MIT License.
 
+using System.Collections.Generic;
+
 namespace Microsoft.Identity.Abstractions
 {
     /// <summary>
@@ -8,8 +10,9 @@ namespace Microsoft.Identity.Abstractions
     /// exposed by the underlying token-service exception.
     /// </summary>
     /// <remarks>
-    /// All members are diagnostic only. Do not program against specific values of <see cref="SubError"/>
-    /// or <see cref="ErrorCode"/>; they are set by the token service and may change without notice.
+    /// All members are diagnostic only. Do not program against specific values of <see cref="SubError"/>,
+    /// <see cref="ErrorCode"/>, or <see cref="ServiceErrorCodes"/>; they are set by the token service and
+    /// may change without notice.
     /// </remarks>
     public sealed class TokenAcquisitionFailureDetails
     {
@@ -25,6 +28,13 @@ namespace Microsoft.Identity.Abstractions
         /// diagnostic only.
         /// </summary>
         public string? SubError { get; init; }
+
+        /// <summary>
+        /// The raw STS-specific error codes returned by the token service (for example the numeric
+        /// <c>AADSTS</c> codes) that further refine <see cref="ErrorCode"/>. Mirrors
+        /// <c>MsalServiceException.ErrorCodes</c> when MSAL is the underlying acquirer; diagnostic only.
+        /// </summary>
+        public IReadOnlyList<string>? ServiceErrorCodes { get; init; }
 
         /// <summary>
         /// HTTP status code returned by the token endpoint, when available.

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/net10.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/net10.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.Identity.Abstractions.TokenAcquisitionFailureDetails.ServiceErrorCodes.get -> System.Collections.Generic.IReadOnlyList<string!>?
+Microsoft.Identity.Abstractions.TokenAcquisitionFailureDetails.ServiceErrorCodes.init -> void

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/net462/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/net462/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.Identity.Abstractions.TokenAcquisitionFailureDetails.ServiceErrorCodes.get -> System.Collections.Generic.IReadOnlyList<string!>?
+Microsoft.Identity.Abstractions.TokenAcquisitionFailureDetails.ServiceErrorCodes.init -> void

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.Identity.Abstractions.TokenAcquisitionFailureDetails.ServiceErrorCodes.get -> System.Collections.Generic.IReadOnlyList<string!>?
+Microsoft.Identity.Abstractions.TokenAcquisitionFailureDetails.ServiceErrorCodes.init -> void

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/net9.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/net9.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.Identity.Abstractions.TokenAcquisitionFailureDetails.ServiceErrorCodes.get -> System.Collections.Generic.IReadOnlyList<string!>?
+Microsoft.Identity.Abstractions.TokenAcquisitionFailureDetails.ServiceErrorCodes.init -> void

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.Identity.Abstractions.TokenAcquisitionFailureDetails.ServiceErrorCodes.get -> System.Collections.Generic.IReadOnlyList<string!>?
+Microsoft.Identity.Abstractions.TokenAcquisitionFailureDetails.ServiceErrorCodes.init -> void

--- a/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/src/Microsoft.Identity.Abstractions/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
@@ -1,1 +1,3 @@
 #nullable enable
+Microsoft.Identity.Abstractions.TokenAcquisitionFailureDetails.ServiceErrorCodes.get -> System.Collections.Generic.IReadOnlyList<string!>?
+Microsoft.Identity.Abstractions.TokenAcquisitionFailureDetails.ServiceErrorCodes.init -> void

--- a/test/Microsoft.Identity.Abstractions.Tests/AuthorizationHeaderTests.cs
+++ b/test/Microsoft.Identity.Abstractions.Tests/AuthorizationHeaderTests.cs
@@ -276,5 +276,43 @@ namespace Microsoft.Identity.Abstractions.Tests
             // Assert
             Assert.Null(info.BindingCertificate);
         }
+
+        [Fact]
+        public void TokenAcquisitionFailureDetails_Properties_CanBeSet()
+        {
+            // Arrange & Act
+            var details = new TokenAcquisitionFailureDetails
+            {
+                ErrorCode = "invalid_grant",
+                SubError = "bad_token",
+                ServiceErrorCodes = new[] { "50076", "500011" },
+                StatusCode = 400,
+                Claims = "******",
+                CorrelationId = "00000000-0000-0000-0000-000000000000"
+            };
+
+            // Assert
+            Assert.Equal("invalid_grant", details.ErrorCode);
+            Assert.Equal("bad_token", details.SubError);
+            Assert.Equal(new[] { "50076", "500011" }, details.ServiceErrorCodes);
+            Assert.Equal(400, details.StatusCode);
+            Assert.Equal("******", details.Claims);
+            Assert.Equal("00000000-0000-0000-0000-000000000000", details.CorrelationId);
+        }
+
+        [Fact]
+        public void TokenAcquisitionFailureDetails_DefaultValues_AreNull()
+        {
+            // Arrange & Act
+            var details = new TokenAcquisitionFailureDetails();
+
+            // Assert
+            Assert.Null(details.ErrorCode);
+            Assert.Null(details.SubError);
+            Assert.Null(details.ServiceErrorCodes);
+            Assert.Null(details.StatusCode);
+            Assert.Null(details.Claims);
+            Assert.Null(details.CorrelationId);
+        }
     }
 }


### PR DESCRIPTION
## What
Add `IReadOnlyList<string>? ServiceErrorCodes` to `TokenAcquisitionFailureDetails`.

## Why
Surfaces the raw STS-specific error codes (numeric `AADSTS` codes, e.g. `50076`, `500011`) that refine `ErrorCode`, mirroring `MsalServiceException.ErrorCodes`. Diagnostic only — values are service-emitted and may change.

## Notes
- Additive `init`-only property; `<remarks>` updated to list it alongside the other diagnostic-only members.
- Adds companion tests for `TokenAcquisitionFailureDetails` (the POCO previously had no coverage).

## Related
- MSAL: AzureAD/microsoft-authentication-library-for-dotnet#6138 (exposes `MsalServiceException.ErrorCodes`, the source of this value).
- Consumed by MISE (maps `MsalServiceException.ErrorCodes` → `ServiceErrorCodes`).
- MISE follow-up (draft, ADO): https://identitydivision.visualstudio.com/DevEx/_git/MISE/pullrequest/25683
